### PR TITLE
Add option to sort codes by domain/page

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Browser extension for generating and managing two-factor authentication codes.
 
 - Generate TOTP, HOTP, and Steam-style 2FA codes.
 - Add accounts from QR images, page QR scans, pasted otpauth text, or manual entry.
-- Search, copy, and drag-reorder accounts.
+- Search, copy, manually reorder accounts, or prioritize likely codes for the current site.
 - Import/export otpauth text and encrypted backups.
 - Optional local vault password protection.
 - Local-first storage with no account service.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@lucide/svelte": "^1.18.0",
         "qrcode": "^1.5.4",
+        "tldts": "^7.4.10",
         "zxing-wasm": "^3.1.0"
       },
       "devDependencies": {
@@ -4078,6 +4079,24 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "license": "MIT"
     },
     "node_modules/tmcp": {
       "version": "1.19.4",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@lucide/svelte": "^1.18.0",
     "qrcode": "^1.5.4",
+    "tldts": "^7.4.10",
     "zxing-wasm": "^3.1.0"
   },
   "devDependencies": {

--- a/scripts/generate-store-screenshots.mjs
+++ b/scripts/generate-store-screenshots.mjs
@@ -212,6 +212,7 @@ function renderDemoPage(scenario) {
       settings: {
         language: 'en',
         theme: scenario.theme,
+        accountSortMode: 'contextual',
       },
     },
     createdAt: '2026-01-01T00:00:00.000Z',

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -34,6 +34,7 @@
     rubberbandOffset
   } from './lib/components/auth/reorder';
   import { accountToOtpAuthUri } from './lib/auth/otpauth';
+  import { rankAccountsForPage, type PageContext } from './lib/auth/accountRanking';
   import { decodeQrFiles, renderQrDataUrl } from './lib/auth/qr';
   import type { AccountDraft, AuthenticatorAccount, ImportResult } from './lib/auth/types';
   import { authenticatorVault as vault } from './lib/state/authenticator.svelte';
@@ -47,12 +48,19 @@
     ok?: boolean;
     error?: string;
     pasted?: boolean;
+    pageContext?: PageContext | null;
   }
 
   interface PageScanCompletedMessage {
     type: 'page-scan:completed';
     ok: boolean;
     message: string;
+  }
+
+  interface ActivePageContextChangedMessage {
+    type: 'active-page-context-changed';
+    windowId: number;
+    clearCurrent: boolean;
   }
 
   interface AccountDragRect {
@@ -108,8 +116,16 @@
   let pageScanState = $state<PageScanState>('idle');
   let pageScanMessage = $state('');
   let pageScanError = $state('');
+  let pageContext = $state.raw<PageContext | null>(null);
+  let pageContextReady = $state(false);
+  let pageContextRequest = 0;
+  let browserWindowId: number | undefined;
 
-  const orderedAccounts = $derived.by(() => dragAccounts ?? vault.sortedAccounts);
+  const manualSort = $derived(vault.settings.accountSortMode === 'manual');
+  const contextualAccounts = $derived.by(() =>
+    manualSort ? vault.sortedAccounts : rankAccountsForPage(vault.sortedAccounts, pageContext)
+  );
+  const orderedAccounts = $derived.by(() => dragAccounts ?? contextualAccounts);
   const filteredAccounts = $derived.by(() => {
     const needle = query.trim().toLowerCase();
     if (!needle) {
@@ -120,12 +136,15 @@
         account.label.toLowerCase().includes(needle) || account.issuer.toLowerCase().includes(needle)
     );
   });
-  const reorderDisabled = $derived(query.trim().length > 0 || filteredAccounts.length < 2);
+  const reorderDisabled = $derived(
+    !manualSort || query.trim().length > 0 || filteredAccounts.length < 2
+  );
   const activeDragAccountId = $derived(dragState?.accountId ?? keyboardDraggingAccountId);
   const pageScanBusy = $derived(pageScanState !== 'idle');
   const themeOverride = $derived(vault.settings.theme === 'system' ? undefined : vault.settings.theme);
 
   function showSettings(event: MouseEvent) {
+    cleanupAccountDrag();
     animateViewTransition = event.detail > 0;
     view = 'settings';
   }
@@ -142,6 +161,12 @@
     const listener = (message: unknown) => {
       if (isPageScanCompleted(message)) {
         void handlePageScanCompleted(message);
+      } else if (
+        isActivePageContextChanged(message) &&
+        !manualSort &&
+        (browserWindowId === undefined || message.windowId === browserWindowId)
+      ) {
+        void refreshPageContext(message.clearCurrent);
       }
     };
     if (hasRuntimeMessaging()) {
@@ -192,15 +217,72 @@
   });
 
   async function initializeApp() {
-    await vault.initialize();
+    try {
+      browserWindowId = await getCurrentBrowserWindowId();
+      await vault.initialize();
+      await refreshPageContext();
+    } finally {
+      pageContextReady = true;
+    }
   }
 
   async function createVault(password: string) {
-    await vault.create(password);
+    pageContextReady = false;
+    try {
+      await vault.create(password);
+      await refreshPageContext();
+    } finally {
+      pageContextReady = true;
+    }
   }
 
   async function unlockVault(password: string) {
-    await vault.unlock(password);
+    pageContextReady = false;
+    try {
+      await vault.unlock(password);
+      await refreshPageContext();
+    } finally {
+      pageContextReady = true;
+    }
+  }
+
+  async function setContextualSorting(enabled: boolean) {
+    const accountSortMode = enabled ? 'contextual' : 'manual';
+    if (vault.settings.accountSortMode === accountSortMode) {
+      return;
+    }
+
+    cleanupAccountDrag();
+    try {
+      await vault.updateSettings({ accountSortMode });
+      await refreshPageContext();
+    } catch (error) {
+      vault.error = getErrorMessage(error, tr('settingsSaveFailed'));
+    }
+  }
+
+  async function refreshPageContext(clearCurrent = true) {
+    const request = ++pageContextRequest;
+    if (clearCurrent) {
+      pageContext = null;
+    }
+    if (vault.settings.accountSortMode === 'manual' || !hasRuntimeMessaging()) {
+      pageContext = null;
+      return;
+    }
+
+    try {
+      const response = await sendRuntimeMessage({
+        type: 'get-active-page-context',
+        windowId: browserWindowId
+      });
+      if (request === pageContextRequest) {
+        pageContext = parsePageContext(response.pageContext);
+      }
+    } catch {
+      // Context is optional. Manual order is the quiet fallback when the
+      // browser cannot expose active-tab metadata.
+    }
   }
 
   function openAddDialog(mode: AddMode = 'qr') {
@@ -398,6 +480,18 @@
     });
   }
 
+  function getCurrentBrowserWindowId(): Promise<number | undefined> {
+    if (typeof chrome === 'undefined' || typeof chrome.windows?.getCurrent !== 'function') {
+      return Promise.resolve(undefined);
+    }
+
+    return new Promise((resolve) => {
+      chrome.windows.getCurrent((currentWindow) => {
+        resolve(chrome.runtime.lastError ? undefined : currentWindow.id);
+      });
+    });
+  }
+
   function isPageScanCompleted(message: unknown): message is PageScanCompletedMessage {
     return (
       typeof message === 'object' &&
@@ -406,6 +500,37 @@
       typeof (message as { ok?: unknown }).ok === 'boolean' &&
       typeof (message as { message?: unknown }).message === 'string'
     );
+  }
+
+  function isActivePageContextChanged(
+    message: unknown
+  ): message is ActivePageContextChangedMessage {
+    return (
+      typeof message === 'object' &&
+      message !== null &&
+      (message as { type?: unknown }).type === 'active-page-context-changed' &&
+      Number.isSafeInteger((message as { windowId?: unknown }).windowId) &&
+      typeof (message as { clearCurrent?: unknown }).clearCurrent === 'boolean'
+    );
+  }
+
+  function parsePageContext(value: unknown): PageContext | null {
+    if (!value || typeof value !== 'object') {
+      return null;
+    }
+
+    const context = value as { hostname?: unknown; title?: unknown };
+    if (
+      typeof context.hostname !== 'string' ||
+      context.hostname.length === 0 ||
+      context.hostname.length > 253
+    ) {
+      return null;
+    }
+    return {
+      hostname: context.hostname,
+      ...(typeof context.title === 'string' ? { title: context.title.slice(0, 512) } : {})
+    };
   }
 
   async function handlePageScanCompleted(message: PageScanCompletedMessage) {
@@ -430,6 +555,7 @@
     showAdd = false;
     view = 'codes';
     await vault.initialize();
+    await refreshPageContext();
   }
 
   function getErrorMessage(error: unknown, fallback: string): string {
@@ -815,7 +941,7 @@
 <main
   class="relative flex h-full min-h-0 w-full min-w-0 flex-col overflow-hidden bg-base-100 text-base-content"
 >
-  {#if !vault.initialized}
+  {#if !vault.initialized || (!vault.locked && !pageContextReady)}
     <div class="grid h-full place-items-center">
       <span class="loading loading-spinner loading-lg text-primary"></span>
     </div>
@@ -834,7 +960,7 @@
           class="absolute inset-0 z-10 flex min-h-0 flex-col overflow-hidden bg-base-100"
           transition:viewTransition={{ x: 20, instant: !animateViewTransition }}
         >
-          <SettingsView onback={showCodes} />
+          <SettingsView onback={showCodes} oncontextualsortchange={setContextualSorting} />
         </div>
       {:else}
         <div
@@ -856,13 +982,14 @@
             {#if filteredAccounts.length > 0}
               <ul
                 class="divide-y divide-base-200"
-                aria-label={tr('reorderAccounts')}
+                aria-label={tr('accounts')}
                 bind:this={accountListElement}
               >
                 {#each filteredAccounts as account (account.id)}
                   <AccountRow
                     {account}
                     code={vault.codes[account.id]}
+                    showReorder={manualSort}
                     reorderDisabled={reorderDisabled}
                     reorderPending={reorderSaving}
                     dragging={activeDragAccountId === account.id}

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,4 +1,5 @@
 import { decodeQrDataUrlInWorker } from './lib/auth/qrWorker';
+import type { PageContext } from './lib/auth/accountRanking';
 import { getImportResultMessage, importTextIntoStoredVault } from './lib/auth/vaultImport';
 
 interface CaptureRect {
@@ -13,6 +14,7 @@ interface MessageResponse {
   ok: boolean;
   error?: string;
   pasted?: boolean;
+  pageContext?: PageContext | null;
 }
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
@@ -23,6 +25,11 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
   if (message?.type === 'start-page-scan') {
     respond(sendResponse, startPageScan());
+    return true;
+  }
+
+  if (message?.type === 'get-active-page-context') {
+    respond(sendResponse, getActivePageContext(readWindowId(message.windowId)));
     return true;
   }
 
@@ -47,6 +54,49 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
   return undefined;
 });
+
+chrome.tabs.onActivated.addListener(({ windowId }) => notifyActivePageChanged(windowId, true));
+chrome.tabs.onUpdated.addListener((_tabId, changeInfo, tab) => {
+  if (!tab.active) {
+    return;
+  }
+  if (changeInfo.url !== undefined || changeInfo.status !== undefined) {
+    notifyActivePageChanged(tab.windowId, true);
+  } else if (changeInfo.title !== undefined) {
+    notifyActivePageChanged(tab.windowId, false);
+  }
+});
+chrome.windows.onFocusChanged.addListener((windowId) => {
+  if (windowId !== chrome.windows.WINDOW_ID_NONE) {
+    notifyActivePageChanged(windowId, true);
+  }
+});
+
+async function getActivePageContext(windowId: number | undefined): Promise<Partial<MessageResponse>> {
+  const tab = await getActiveTab(windowId);
+  if (!tab?.url || isRestrictedPage(tab.url)) {
+    return { pageContext: null };
+  }
+
+  try {
+    const url = new URL(tab.url);
+    if (!['http:', 'https:'].includes(url.protocol)) {
+      return { pageContext: null };
+    }
+    return {
+      pageContext: {
+        hostname: url.hostname,
+        ...(tab.title ? { title: tab.title.slice(0, 512) } : {})
+      }
+    };
+  } catch {
+    return { pageContext: null };
+  }
+}
+
+function notifyActivePageChanged(windowId: number, clearCurrent: boolean): void {
+  sendRuntimeMessage({ type: 'active-page-context-changed', windowId, clearCurrent });
+}
 
 async function startPageScan(): Promise<void> {
   const tab = await getActiveTab();
@@ -138,12 +188,17 @@ async function reportScanFailure(tabId: number | undefined, message: unknown): P
   sendRuntimeMessage({ type: 'page-scan:completed', ok: false, message: resultMessage });
 }
 
-function getActiveTab(): Promise<chrome.tabs.Tab | undefined> {
+function getActiveTab(windowId?: number): Promise<chrome.tabs.Tab | undefined> {
   return new Promise((resolve, reject) => {
-    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+    const query = windowId === undefined ? { active: true, currentWindow: true } : { active: true, windowId };
+    chrome.tabs.query(query, (tabs) => {
       settleChromeCallback(() => resolve(tabs[0]), reject);
     });
   });
+}
+
+function readWindowId(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
 }
 
 function executeScript(tabId: number, file: string): Promise<void> {

--- a/src/lib/auth/accountRanking.ts
+++ b/src/lib/auth/accountRanking.ts
@@ -1,0 +1,306 @@
+import { parse } from 'tldts';
+import { SITE_IDENTITY_OVERRIDES } from './accountSiteMetadata';
+import type { AuthenticatorAccount } from './types';
+
+export interface PageContext {
+  hostname?: string;
+  title?: string;
+}
+
+interface NameProfile {
+  exact: Set<string>;
+  whole: Set<string>;
+  tokens: Set<string>;
+  phrases: string[];
+}
+
+interface PageIdentity {
+  siteKey: string;
+  exactSiteKeys: Set<string>;
+  aliases: Set<string>;
+  title: string;
+  titleTokens: Set<string>;
+}
+
+interface MatchWeights {
+  whole: number;
+  token: number;
+  aliasWhole: number;
+  aliasToken: number;
+}
+
+const NAME_NOISE = new Set([
+  '2fa',
+  'account',
+  'accounts',
+  'auth',
+  'authentication',
+  'authenticator',
+  'co',
+  'com',
+  'code',
+  'codes',
+  'default',
+  'dev',
+  'io',
+  'login',
+  'net',
+  'org',
+  'otp',
+  'security',
+  'signin',
+  'totp',
+  'verification',
+  'verify',
+  'website'
+]);
+
+const GENERIC_ISSUERS = new Set([
+  '',
+  '2fa',
+  'authenticator',
+  'default',
+  'other',
+  'otp',
+  'personal',
+  'security',
+  'totp',
+  'work'
+]);
+
+const ISSUER_WEIGHTS: MatchWeights = {
+  whole: 120,
+  token: 105,
+  aliasWhole: 130,
+  aliasToken: 115
+};
+
+const PRIMARY_LABEL_WEIGHTS: MatchWeights = {
+  whole: 100,
+  token: 85,
+  aliasWhole: 110,
+  aliasToken: 95
+};
+
+const SECONDARY_LABEL_WEIGHTS: MatchWeights = {
+  whole: 75,
+  token: 65,
+  aliasWhole: 80,
+  aliasToken: 70
+};
+
+const MIN_MATCH_SCORE = 60;
+const MIN_PARTIAL_ALIAS_LENGTH = 3;
+
+const ALIAS_PROFILES = SITE_IDENTITY_OVERRIDES.map((entry) => ({
+  domains: entry.domains,
+  names: new Set(entry.names.map(compact))
+}));
+
+/**
+ * Returns a new array with likely matches for the current page first. Equal
+ * and unmatched accounts retain their incoming (normally manual) order.
+ */
+export function rankAccountsForPage(
+  accounts: readonly AuthenticatorAccount[],
+  context: PageContext | null
+): AuthenticatorAccount[] {
+  const page = getPageIdentity(context);
+  if (!page) {
+    return [...accounts];
+  }
+
+  return accounts
+    .map((account, index) => ({ account, index, score: scoreAccount(account, page) }))
+    .sort((left, right) => right.score - left.score || left.index - right.index)
+    .map(({ account }) => account);
+}
+
+export function getAccountPageMatchScore(
+  account: AuthenticatorAccount,
+  context: PageContext | null
+): number {
+  const page = getPageIdentity(context);
+  return page ? scoreAccount(account, page) : 0;
+}
+
+function scoreAccount(account: AuthenticatorAccount, page: PageIdentity): number {
+  const issuer = createNameProfile(account.issuer);
+  const issuerIsGeneric = GENERIC_ISSUERS.has([...issuer.whole][0] ?? '');
+  const label = createNameProfile(
+    issuerIsGeneric ? account.label : removeEmailAddresses(account.label)
+  );
+  const primary = issuerIsGeneric ? label : issuer;
+  const secondary = issuerIsGeneric ? emptyNameProfile() : label;
+
+  const primaryScore = issuerIsGeneric
+    ? scoreNameProfile(primary, page, PRIMARY_LABEL_WEIGHTS)
+    : scoreNameProfile(primary, page, ISSUER_WEIGHTS);
+  const secondaryScore = scoreNameProfile(secondary, page, SECONDARY_LABEL_WEIGHTS);
+  let score = Math.max(primaryScore, secondaryScore);
+
+  // A page title can increase confidence, but cannot promote an account on an
+  // unrelated or lookalike domain by itself.
+  if (score >= MIN_MATCH_SCORE) {
+    const matchedProfile = primaryScore >= secondaryScore ? primary : secondary;
+    if (matchedProfile.phrases.some((phrase) => includesPhrase(page.title, phrase))) {
+      score += 5;
+    } else if ([...matchedProfile.tokens].some((token) => page.titleTokens.has(token))) {
+      score += 3;
+    }
+  }
+
+  return score >= MIN_MATCH_SCORE ? score : 0;
+}
+
+function scoreNameProfile(
+  profile: NameProfile,
+  page: PageIdentity,
+  weights: MatchWeights
+): number {
+  let score = 0;
+  if (
+    intersects(profile.exact, page.exactSiteKeys) ||
+    intersects(profile.whole, page.exactSiteKeys)
+  ) {
+    score = weights.whole;
+  } else if (
+    page.siteKey.length >= 3 &&
+    profile.tokens.has(page.siteKey)
+  ) {
+    score = weights.token;
+  }
+
+  if (intersects(profile.exact, page.aliases) || intersects(profile.whole, page.aliases)) {
+    score = Math.max(score, weights.aliasWhole);
+  } else if (
+    [...profile.tokens].some(
+      (value) => value.length >= MIN_PARTIAL_ALIAS_LENGTH && page.aliases.has(value)
+    )
+  ) {
+    score = Math.max(score, weights.aliasToken);
+  }
+  return score;
+}
+
+function getPageIdentity(context: PageContext | null): PageIdentity | null {
+  if (!context?.hostname) {
+    return null;
+  }
+  const hostname = context.hostname.toLowerCase().replace(/\.$/, '');
+  if (!hostname) {
+    return null;
+  }
+  const aliases = getAliasProfile(hostname);
+  const parsed = parse(hostname, {
+    allowPrivateDomains: true,
+    detectSpecialUse: true,
+    extractHostname: false
+  });
+  if (!parsed.hostname) {
+    return null;
+  }
+  // Private suffix tenants are controlled independently of the apparent
+  // parent brand. Only an explicit override may opt one back in.
+  if (parsed.isPrivate && aliases.size === 0) {
+    return null;
+  }
+
+  // An explicit override replaces the generic parent-domain identity. On an
+  // AWS sign-in host, for example, an Amazon shopping code is not a match.
+  const siteKey = aliases.size
+    ? ''
+    : compact(
+        parsed.domainWithoutSuffix ??
+          (parsed.isIp || !hostname.includes('.') ? hostname : '')
+      );
+  if (!siteKey && aliases.size === 0) {
+    return null;
+  }
+  const title = normalizeWords(context.title ?? '');
+
+  return {
+    siteKey,
+    exactSiteKeys: new Set(
+      aliases.size === 0
+        ? [siteKey, compact(parsed.domain ?? '')].filter(Boolean)
+        : []
+    ),
+    aliases,
+    title,
+    titleTokens: new Set(title.split(' ').filter(isMeaningfulToken))
+  };
+}
+
+function getAliasProfile(hostname: string): Set<string> {
+  const matches = ALIAS_PROFILES.flatMap(({ domains, names }) => {
+    const domain = domains
+      .filter((candidate) => hostname === candidate || hostname.endsWith(`.${candidate}`))
+      .sort((left, right) => right.length - left.length)[0];
+    return domain ? [{ domain, names }] : [];
+  });
+  const mostSpecificLength = Math.max(0, ...matches.map(({ domain }) => domain.length));
+  return new Set(
+    matches
+      .filter(({ domain }) => domain.length === mostSpecificLength)
+      .flatMap(({ names }) => [...names])
+  );
+}
+
+function createNameProfile(value: string): NameProfile {
+  const phrase = normalizeWords(value);
+  if (!phrase) {
+    return emptyNameProfile();
+  }
+
+  const allTokens = phrase.split(' ');
+  const wholeTokens = allTokens.filter((token) => !NAME_NOISE.has(token));
+  const tokens = wholeTokens.filter(isMeaningfulToken);
+
+  return {
+    exact: new Set([allTokens.join('')]),
+    whole: new Set(wholeTokens.length > 0 ? [wholeTokens.join('')] : []),
+    tokens: new Set(tokens),
+    phrases: [phrase]
+  };
+}
+
+function emptyNameProfile(): NameProfile {
+  return {
+    exact: new Set(),
+    whole: new Set(),
+    tokens: new Set(),
+    phrases: []
+  };
+}
+
+function normalizeWords(value: string): string {
+  return value
+    .normalize('NFKD')
+    .replace(/\p{M}+/gu, '')
+    .toLocaleLowerCase('en-US')
+    .replace(/&/g, ' and ')
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .trim()
+    .replace(/\s+/g, ' ');
+}
+
+function removeEmailAddresses(value: string): string {
+  return value.replace(/\S+@\S+/gu, ' ');
+}
+
+function compact(value: string): string {
+  return normalizeWords(value).replace(/ /g, '');
+}
+
+function isMeaningfulToken(token: string): boolean {
+  return token.length >= 2 && !NAME_NOISE.has(token);
+}
+
+function includesPhrase(text: string, phrase: string): boolean {
+  return Boolean(phrase) && ` ${text} `.includes(` ${phrase} `);
+}
+
+function intersects(left: Set<string>, right: Set<string>): boolean {
+  return [...left].some((value) => right.has(value));
+}

--- a/src/lib/auth/accountSiteMetadata.ts
+++ b/src/lib/auth/accountSiteMetadata.ts
@@ -1,0 +1,92 @@
+export interface SiteIdentityOverride {
+  readonly domains: readonly string[];
+  readonly names: readonly string[];
+}
+
+/**
+ * Domain-scoped issuer names used when a service has been renamed, uses a
+ * shared account system, or has a web domain that differs from its 2FA label.
+ *
+ * Keep entries conservative:
+ * - Use registrable domains or tightly scoped first-party sign-in hosts.
+ * - Include only names that use the same credentials, including historical
+ *   names; a corporate relationship or optional account link is not enough.
+ * - Do not add user-hosted suffixes (for example, github.io or pages.dev).
+ *
+ * A more-specific domain wins over a parent-domain entry in the ranking
+ * engine, so product-specific identities stay isolated from sibling products.
+ */
+export const SITE_IDENTITY_OVERRIDES = [
+  // Renames and long-lived historical labels.
+  { domains: ['x.com', 'twitter.com'], names: ['X', 'Twitter'] },
+  { domains: ['proton.me', 'protonmail.com', 'protonvpn.com'], names: ['Proton', 'Proton Mail', 'Proton VPN', 'Proton Pass', 'Proton Drive'] },
+  { domains: ['wise.com', 'transferwise.com'], names: ['Wise', 'TransferWise'] },
+  { domains: ['discord.com', 'discordapp.com'], names: ['Discord', 'Discord App'] },
+  { domains: ['tuta.com', 'tutanota.com'], names: ['Tuta', 'Tuta Mail', 'Tutanota'] },
+  { domains: ['max.com', 'hbomax.com'], names: ['Max', 'HBO Max'] },
+  { domains: ['ubisoft.com'], names: ['Ubisoft', 'Ubisoft Connect', 'Ubisoft Club', 'Uplay'] },
+  { domains: ['ea.com', 'origin.com'], names: ['EA', 'Electronic Arts', 'Origin'] },
+  { domains: ['goto.com', 'logmein.com'], names: ['GoTo', 'LogMeIn', 'GoTo Connect', 'GoTo Resolve'] },
+  { domains: ['sign.dropbox.com', 'hellosign.com'], names: ['Dropbox Sign', 'HelloSign'] },
+  { domains: ['gusto.com'], names: ['Gusto', 'ZenPayroll'] },
+  { domains: ['miro.com'], names: ['Miro', 'RealtimeBoard'] },
+  { domains: ['monday.com'], names: ['monday', 'dapulse'] },
+
+  // Shared consumer and productivity account systems.
+  { domains: ['accounts.google.com', 'workspace.google.com'], names: ['Google', 'Google Workspace', 'G Suite', 'Google Apps'] },
+  { domains: ['gmail.com', 'googlemail.com'], names: ['Google', 'Gmail', 'Google Mail'] },
+  { domains: ['youtube.com', 'youtu.be'], names: ['Google', 'YouTube'] },
+  { domains: ['fitbit.com'], names: ['Fitbit', 'Google'] },
+  { domains: ['nest.com'], names: ['Nest', 'Google Nest', 'Google Home', 'Google'] },
+  { domains: ['icloud.com', 'me.com'], names: ['Apple', 'Apple ID', 'iCloud', 'MobileMe'] },
+  { domains: ['microsoftonline.com', 'entra.microsoft.com'], names: ['Microsoft', 'Microsoft 365', 'M365', 'Office 365', 'O365', 'Azure AD', 'Azure Active Directory', 'AAD', 'Entra ID'] },
+  { domains: ['login.live.com', 'account.live.com'], names: ['Microsoft', 'Live', 'Outlook', 'Hotmail'] },
+  { domains: ['outlook.com', 'hotmail.com'], names: ['Microsoft', 'Outlook', 'Hotmail'] },
+  { domains: ['xbox.com'], names: ['Microsoft', 'Xbox', 'Xbox Live'] },
+  { domains: ['office.com', 'office365.com', 'microsoft365.com'], names: ['Microsoft', 'Microsoft 365', 'M365', 'Office', 'Office 365', 'O365'] },
+  { domains: ['onedrive.com', 'onedrive.live.com'], names: ['Microsoft', 'OneDrive', 'Live'] },
+  { domains: ['skype.com'], names: ['Microsoft', 'Skype'] },
+  { domains: ['azure.com'], names: ['Microsoft', 'Azure', 'Microsoft Azure', 'Azure AD', 'Entra ID'] },
+  { domains: ['dev.azure.com', 'visualstudio.com'], names: ['Microsoft', 'Azure', 'Azure DevOps', 'Visual Studio', 'Visual Studio Team Services', 'VSTS'] },
+  { domains: ['minecraft.net'], names: ['Microsoft', 'Xbox', 'Minecraft', 'Mojang'] },
+  { domains: ['messenger.com'], names: ['Messenger', 'Facebook'] },
+  { domains: ['threads.com', 'threads.net'], names: ['Threads', 'Instagram'] },
+  { domains: ['meta.com', 'oculus.com'], names: ['Meta', 'Meta Quest', 'Meta Horizon', 'Oculus'] },
+  { domains: ['accounts.firefox.com'], names: ['Mozilla', 'Firefox'] },
+  { domains: ['trello.com'], names: ['Atlassian', 'Trello'] },
+  { domains: ['bitbucket.org'], names: ['Atlassian', 'Bitbucket'] },
+  { domains: ['behance.net'], names: ['Adobe', 'Adobe ID', 'Behance'] },
+  { domains: ['audible.com'], names: ['Amazon', 'Audible'] },
+  { domains: ['primevideo.com'], names: ['Amazon', 'Amazon Prime', 'Prime Video'] },
+  { domains: ['quickbooks.com'], names: ['Intuit', 'QuickBooks'] },
+  { domains: ['turbotax.com'], names: ['Intuit', 'TurboTax'] },
+  { domains: ['nordaccount.com', 'nordvpn.com', 'nordpass.com', 'nordlocker.com'], names: ['Nord', 'Nord Security', 'NordVPN', 'NordPass', 'NordLocker'] },
+
+  // Popular sites whose common 2FA issuer differs from the web domain.
+  { domains: ['openai.com', 'chatgpt.com'], names: ['OpenAI', 'ChatGPT'] },
+  { domains: ['claude.ai'], names: ['Anthropic', 'Claude'] },
+  { domains: ['aws.amazon.com'], names: ['AWS', 'Amazon Web Services'] },
+  { domains: ['awsapps.com'], names: ['AWS', 'Amazon Web Services', 'AWS SSO', 'AWS IAM Identity Center', 'IAM Identity Center'] },
+  { domains: ['battle.net', 'blizzard.com'], names: ['Battle.net', 'Blizzard', 'Blizzard Entertainment'] },
+  { domains: ['playstation.com'], names: ['PlayStation', 'Sony', 'Sony Entertainment Network', 'SEN'] },
+  { domains: ['steampowered.com', 'steamcommunity.com'], names: ['Steam', 'Valve'] },
+  { domains: ['epicgames.com'], names: ['Epic', 'Epic Games'] },
+  { domains: ['fortnite.com'], names: ['Epic Games', 'Fortnite'] },
+  { domains: ['leagueoflegends.com'], names: ['Riot', 'Riot Games', 'League of Legends'] },
+  { domains: ['valorant.com'], names: ['Riot', 'Riot Games', 'VALORANT'] },
+  { domains: ['socialclub.rockstargames.com'], names: ['Rockstar', 'Rockstar Games', 'Rockstar Social Club', 'Social Club'] },
+  { domains: ['unity.com', 'unity3d.com'], names: ['Unity', 'Unity ID', 'Unity3D'] },
+  { domains: ['npmjs.com'], names: ['npm', 'npmjs', 'npm registry'] },
+  { domains: ['oraclecloud.com'], names: ['Oracle', 'Oracle Cloud'] },
+  { domains: ['duosecurity.com'], names: ['Duo', 'Duo Security', 'Cisco Duo'] },
+  { domains: ['webex.com'], names: ['Webex', 'Cisco Webex'] },
+  { domains: ['keepersecurity.com'], names: ['Keeper', 'Keeper Security'] },
+  { domains: ['id.me'], names: ['ID.me'] },
+  { domains: ['login.gov'], names: ['Login.gov'] },
+  { domains: ['mi.com'], names: ['Mi', 'Xiaomi'] },
+  { domains: ['wikipedia.org', 'wikimedia.org'], names: ['Wikipedia', 'Wikimedia'] },
+  { domains: ['support.broadcom.com', 'vmware.com'], names: ['Broadcom', 'VMware', 'VMware Customer Connect'] },
+  { domains: ['nytimes.com'], names: ['NYTimes', 'New York Times', 'The New York Times'] },
+  { domains: ['ft.com'], names: ['FT', 'Financial Times', 'The Financial Times'] },
+  { domains: ['squareup.com'], names: ['Square', 'Squareup'] }
+] as const satisfies readonly SiteIdentityOverride[];

--- a/src/lib/auth/types.ts
+++ b/src/lib/auth/types.ts
@@ -4,6 +4,8 @@ export type OtpAlgorithm = 'SHA-1' | 'SHA-256' | 'SHA-512';
 
 export type ThemePreference = 'system' | 'light' | 'dark';
 
+export type AccountSortMode = 'manual' | 'contextual';
+
 export interface AuthenticatorAccount {
   id: string;
   issuer: string;
@@ -55,6 +57,7 @@ export interface AppSettings {
   theme: ThemePreference;
   showCountdownSeconds: boolean;
   autoPasteCodes: boolean;
+  accountSortMode: AccountSortMode;
 }
 
 export interface VaultEnvelope {
@@ -88,8 +91,17 @@ export const DEFAULT_SETTINGS: AppSettings = {
   language: 'en',
   theme: 'system',
   showCountdownSeconds: false,
-  autoPasteCodes: false
+  autoPasteCodes: false,
+  accountSortMode: 'contextual'
 };
+
+export function normalizeAppSettings(settings: Partial<AppSettings> | undefined): AppSettings {
+  return {
+    ...DEFAULT_SETTINGS,
+    ...settings,
+    accountSortMode: settings?.accountSortMode === 'manual' ? 'manual' : 'contextual'
+  };
+}
 
 export const OTP_ALGORITHMS: OtpAlgorithm[] = ['SHA-1', 'SHA-256', 'SHA-512'];
 

--- a/src/lib/auth/vaultImport.ts
+++ b/src/lib/auth/vaultImport.ts
@@ -2,22 +2,19 @@ import { importAnyText } from './importText';
 import {
   loadStoredVault,
   loadVaultSessionKey,
-  saveStoredVault,
-  saveVaultSessionKey
+  saveStoredVault
 } from './storage';
 import { normalizeImportedAccounts } from './otp';
 import type {
-  AppSettings,
   AuthenticatorAccount,
   ImportResult,
   PlainVaultRecord,
   VaultData,
   VaultEnvelope
 } from './types';
-import { DEFAULT_SETTINGS } from './types';
+import { DEFAULT_SETTINGS, normalizeAppSettings } from './types';
 import {
   encryptVaultData,
-  exportVaultKey,
   getVaultKeyFingerprint,
   importVaultKey,
   unlockVaultEnvelopeWithKey
@@ -51,7 +48,7 @@ export async function importTextIntoStoredVault(text: string): Promise<ImportRes
   if (merged.imported > 0) {
     await saveLoadedVault(loaded, {
       accounts: merged.accounts,
-      settings: normalizeSettings(loaded.data.settings)
+      settings: normalizeAppSettings(loaded.data.settings)
     });
   }
 
@@ -178,7 +175,7 @@ async function loadUnlockedStoredVault(): Promise<LoadedVault> {
       type: 'plain',
       data: {
         accounts: normalizeAccountOrder(stored.data.accounts),
-        settings: normalizeSettings(stored.data.settings)
+        settings: normalizeAppSettings(stored.data.settings)
       },
       record: stored
     };
@@ -199,7 +196,7 @@ async function loadUnlockedStoredVault(): Promise<LoadedVault> {
     type: 'encrypted',
     data: {
       accounts: normalizeAccountOrder(unlocked.data.accounts),
-      settings: normalizeSettings(unlocked.data.settings)
+      settings: normalizeAppSettings(unlocked.data.settings)
     },
     envelope: stored,
     key
@@ -209,21 +206,16 @@ async function loadUnlockedStoredVault(): Promise<LoadedVault> {
 async function saveLoadedVault(loaded: LoadedVault, data: VaultData): Promise<void> {
   const normalizedData = {
     accounts: normalizeAccountOrder(data.accounts),
-    settings: normalizeSettings(data.settings)
+    settings: normalizeAppSettings(data.settings)
   };
 
   if (loaded.type === 'encrypted') {
     const envelope = await encryptVaultData(normalizedData, loaded.key, loaded.envelope);
     await saveStoredVault(envelope);
-    await saveVaultSessionKey(getVaultKeyFingerprint(envelope), await exportVaultKey(loaded.key));
     return;
   }
 
   await saveStoredVault(createPlainVaultRecord(normalizedData, loaded.record));
-}
-
-function normalizeSettings(settings: Partial<AppSettings> | undefined): AppSettings {
-  return { ...DEFAULT_SETTINGS, ...settings };
 }
 
 function getSortOrder(account: AuthenticatorAccount): number {

--- a/src/lib/components/auth/AccountRow.svelte
+++ b/src/lib/components/auth/AccountRow.svelte
@@ -8,6 +8,7 @@
   interface Props {
     account: AuthenticatorAccount;
     code?: OtpCode;
+    showReorder?: boolean;
     reorderDisabled?: boolean;
     reorderPending?: boolean;
     dragging?: boolean;
@@ -22,6 +23,7 @@
   let {
     account,
     code,
+    showReorder = true,
     reorderDisabled = false,
     reorderPending = false,
     dragging = false,
@@ -70,38 +72,41 @@
   aria-label={title}
   data-account-id={account.id}
 >
-  <button
-    class={[
-      'btn btn-ghost btn-sm btn-square m-0.5 size-10 shrink-0 touch-none text-base-content/45',
-      reorderDisabled
-        ? 'pointer-events-none opacity-35'
-        : reorderPending
-          ? 'pointer-events-none cursor-default opacity-55'
-          : 'cursor-grab hover:text-base-content active:cursor-grabbing'
-    ]}
-    type="button"
-    disabled={reorderDisabled}
-    aria-label={`${tr('reorderAccount')}: ${title}`}
-    aria-disabled={reorderDisabled || reorderPending}
-    aria-pressed={dragging}
-    title={tr('reorderAccount')}
-    onpointerdown={(event) => onreorderstart(account, event)}
-    onkeydown={(event) => onreorderkey(account, event)}
-    onblur={() => onreorderblur(account)}
-  >
-    <GripVertical size={18} aria-hidden="true" />
-  </button>
+  {#if showReorder}
+    <button
+      class={[
+        'btn btn-ghost btn-sm btn-square m-0.5 size-10 shrink-0 touch-none text-base-content/45',
+        reorderDisabled
+          ? 'pointer-events-none opacity-35'
+          : reorderPending
+            ? 'pointer-events-none cursor-default opacity-55'
+            : 'cursor-grab hover:text-base-content active:cursor-grabbing'
+      ]}
+      type="button"
+      disabled={reorderDisabled}
+      aria-label={`${tr('reorderAccount')}: ${title}`}
+      aria-disabled={reorderDisabled || reorderPending}
+      aria-pressed={dragging}
+      title={tr('reorderAccount')}
+      onpointerdown={(event) => onreorderstart(account, event)}
+      onkeydown={(event) => onreorderkey(account, event)}
+      onblur={() => onreorderblur(account)}
+    >
+      <GripVertical size={18} aria-hidden="true" />
+    </button>
+  {/if}
 
   <button
     class={[
-      'auth-code-action flex min-w-0 grow items-center gap-3 px-2 py-[0.6rem] text-left hover:bg-base-200/70 focus-visible:bg-base-200/70 focus:outline-none',
+      'auth-code-action flex min-w-0 grow items-center gap-3 py-[0.6rem] text-left hover:bg-base-200/70 focus-visible:bg-base-200/70 focus:outline-none',
+      showReorder ? 'px-2' : 'pl-4 pr-2',
       value ? 'cursor-pointer' : 'cursor-default'
     ]}
     type="button"
     onclick={copy}
     oncontextmenu={copyFromContextMenu}
     disabled={!value}
-    aria-label={tr('copy')}
+    aria-label={`${tr('copy')}: ${title}`}
   >
     <span class="flex min-w-0 grow flex-col">
       <span class="flex min-w-0 items-center gap-1.5 text-sm leading-tight text-base-content/60">
@@ -136,7 +141,7 @@
       <button
         class="btn btn-ghost btn-sm btn-circle"
         type="button"
-        aria-label={tr('next')}
+        aria-label={`${tr('next')}: ${title}`}
         title={tr('next')}
         onclick={() => vault.advanceHotp(account.id)}
       >
@@ -146,7 +151,7 @@
     <button
       class="btn btn-ghost btn-sm btn-circle text-base-content/45 hover:text-base-content"
       type="button"
-      aria-label={tr('edit')}
+      aria-label={`${tr('edit')}: ${title}`}
       onclick={() => onactions(account)}
     >
       <EllipsisVertical size={18} aria-hidden="true" />

--- a/src/lib/components/auth/SettingsView.svelte
+++ b/src/lib/components/auth/SettingsView.svelte
@@ -13,13 +13,15 @@
   } from '@lucide/svelte';
   import ImportExportPanel from './ImportExportPanel.svelte';
   import MotionDialog from './MotionDialog.svelte';
+  import Toast from './Toast.svelte';
   import { FADE_TRANSITION, panelReveal } from './transitions';
   import { authenticatorVault as vault } from '../../state/authenticator.svelte';
   import { LANGUAGES, tr } from '../../i18n/messages';
-  import type { ThemePreference } from '../../auth/types';
+  import type { AppSettings, ThemePreference } from '../../auth/types';
 
   interface Props {
     onback: (event?: MouseEvent) => void;
+    oncontextualsortchange: (enabled: boolean) => void | Promise<void>;
   }
 
   const THEME_OPTIONS = [
@@ -28,7 +30,7 @@
     { theme: 'dark', icon: Moon }
   ] as const;
 
-  let { onback }: Props = $props();
+  let { onback, oncontextualsortchange }: Props = $props();
 
   type Intent = 'idle' | 'enabling' | 'disabling' | 'changing';
 
@@ -38,6 +40,8 @@
   let resetConfirmation = $state('');
   let securityError = $state('');
   let showBackup = $state(false);
+  let sortSaving = $state(false);
+  let securitySaving = $state(false);
   let intent = $state<Intent>('idle');
   let currentPasswordInput = $state<HTMLInputElement | undefined>();
   let newPasswordInput = $state<HTMLInputElement | undefined>();
@@ -45,8 +49,9 @@
   const wantsProtection = $derived(
     vault.passwordProtected ? intent !== 'disabling' : intent === 'enabling'
   );
+  const securityPending = $derived(vault.busy || securitySaving);
   const canApply = $derived(
-    !vault.busy &&
+    !securityPending &&
       newPassword.length >= 8 &&
       newPassword === confirmNewPassword &&
       (intent !== 'changing' || Boolean(currentPassword))
@@ -54,6 +59,7 @@
   // Surface vault-level errors (wrong password, etc.) only while a password
   // change is in progress, alongside local validation messages.
   const passwordError = $derived(securityError || (intent === 'idle' ? '' : vault.error));
+  const settingsToastError = $derived(intent === 'idle' ? vault.error : '');
   const securityPanel = $derived.by((): 'password' | 'disable' | 'change' | null => {
     if (intent === 'enabling' || intent === 'changing') {
       return 'password';
@@ -73,24 +79,36 @@
   });
 
   function setLanguage(language: string) {
-    void vault.replaceSettings({ ...vault.settings, language });
+    saveSettings({ language });
   }
 
   function setTheme(theme: ThemePreference) {
     if (theme !== vault.settings.theme) {
-      void vault.replaceSettings({ ...vault.settings, theme });
+      saveSettings({ theme });
     }
   }
 
   function setShowCountdownSeconds(showCountdownSeconds: boolean) {
-    if (showCountdownSeconds !== vault.settings.showCountdownSeconds) {
-      void vault.replaceSettings({ ...vault.settings, showCountdownSeconds });
-    }
+    saveSettings({ showCountdownSeconds });
   }
 
   function setAutoPasteCodes(autoPasteCodes: boolean) {
-    if (autoPasteCodes !== vault.settings.autoPasteCodes) {
-      void vault.replaceSettings({ ...vault.settings, autoPasteCodes });
+    saveSettings({ autoPasteCodes });
+  }
+
+  function saveSettings(settings: Partial<AppSettings>) {
+    void vault.updateSettings(settings).catch((error: unknown) => {
+      vault.error = error instanceof Error && error.message ? error.message : tr('settingsSaveFailed');
+    });
+  }
+
+  async function setAutoSortCodes(input: HTMLInputElement) {
+    sortSaving = true;
+    try {
+      await oncontextualsortchange(input.checked);
+    } finally {
+      input.checked = vault.settings.accountSortMode === 'contextual';
+      sortSaving = false;
     }
   }
 
@@ -120,40 +138,64 @@
   }
 
   async function applyPassword() {
+    if (securitySaving) {
+      return;
+    }
     securityError = '';
     vault.error = '';
     if (newPassword !== confirmNewPassword) {
       securityError = 'New passwords do not match.';
       return;
     }
-    await vault.changePassword(intent === 'changing' ? currentPassword : '', newPassword);
-    if (!vault.error) {
-      cancel();
+    securitySaving = true;
+    try {
+      await vault.changePassword(intent === 'changing' ? currentPassword : '', newPassword);
+      if (!vault.error) {
+        cancel();
+      }
+    } finally {
+      securitySaving = false;
     }
   }
 
   async function disableProtection() {
+    if (securitySaving) {
+      return;
+    }
     securityError = '';
     vault.error = '';
     if (!currentPassword) {
       securityError = 'Enter the current password.';
       return;
     }
-    await vault.removePassword(currentPassword);
-    if (!vault.error) {
-      cancel();
+    securitySaving = true;
+    try {
+      await vault.removePassword(currentPassword);
+      if (!vault.error) {
+        cancel();
+      }
+    } finally {
+      securitySaving = false;
     }
   }
 
   async function resetVault() {
+    if (securitySaving) {
+      return;
+    }
     securityError = '';
     if (resetConfirmation !== 'DELETE') {
       securityError = tr('deleteVaultConfirm');
       return;
     }
-    await vault.resetVault();
-    resetConfirmation = '';
-    onback();
+    securitySaving = true;
+    try {
+      await vault.resetVault();
+      resetConfirmation = '';
+      onback();
+    } finally {
+      securitySaving = false;
+    }
   }
 </script>
 
@@ -215,9 +257,23 @@
       </label>
     </section>
 
-    <!-- Code entry -->
+    <!-- Codes -->
     <section class="space-y-3">
-      <h2 class="text-xs font-bold uppercase tracking-wide text-base-content/50">{tr('codeEntry')}</h2>
+      <h2 class="text-xs font-bold uppercase tracking-wide text-base-content/50">{tr('accounts')}</h2>
+
+      <label class="flex items-center justify-between gap-3">
+        <span class="min-w-0">
+          <span class="block text-sm font-medium">{tr('autoSortCodes')}</span>
+          <span class="block text-xs text-base-content/60">{tr('autoSortCodesHint')}</span>
+        </span>
+        <input
+          class="toggle toggle-primary shrink-0"
+          type="checkbox"
+          checked={vault.settings.accountSortMode === 'contextual'}
+          disabled={sortSaving}
+          onchange={(event) => void setAutoSortCodes(event.currentTarget)}
+        />
+      </label>
 
       <label class="flex items-center justify-between gap-3">
         <span class="min-w-0">
@@ -271,7 +327,7 @@
           type="checkbox"
           checked={wantsProtection}
           onchange={toggleProtection}
-          disabled={vault.busy}
+          disabled={securityPending}
         />
       </label>
 
@@ -288,6 +344,7 @@
                     bind:this={currentPasswordInput}
                     bind:value={currentPassword}
                     autocomplete="current-password"
+                    disabled={securityPending}
                   />
                 </label>
               {/if}
@@ -299,17 +356,18 @@
                   bind:this={newPasswordInput}
                   bind:value={newPassword}
                   autocomplete="new-password"
+                  disabled={securityPending}
                 />
                 <span class="text-xs text-base-content/50">{tr('passwordHint')}</span>
               </label>
               <label class="grid gap-1.5">
                 <span class="text-sm font-medium">{tr('confirmPassword')}</span>
-                <input class="input input-sm w-full" type="password" bind:value={confirmNewPassword} autocomplete="new-password" />
+                <input class="input input-sm w-full" type="password" bind:value={confirmNewPassword} autocomplete="new-password" disabled={securityPending} />
               </label>
               <div class="grid grid-cols-2 gap-2 pt-1">
-                <button class="btn btn-sm" type="button" onclick={cancel}>{tr('cancel')}</button>
+                <button class="btn btn-sm" type="button" onclick={cancel} disabled={securityPending}>{tr('cancel')}</button>
                 <button class="btn btn-primary btn-sm" type="button" onclick={applyPassword} disabled={!canApply}>
-                  {#if vault.busy}
+                  {#if securityPending}
                     <span class="loading loading-spinner loading-xs"></span>
                   {/if}
                   {intent === 'changing' ? tr('changePassword') : tr('setPassword')}
@@ -326,12 +384,13 @@
                   bind:this={currentPasswordInput}
                   bind:value={currentPassword}
                   autocomplete="current-password"
+                  disabled={securityPending}
                 />
               </label>
               <div class="grid grid-cols-2 gap-2 pt-1">
-                <button class="btn btn-sm" type="button" onclick={cancel}>{tr('cancel')}</button>
-                <button class="btn btn-warning btn-sm" type="button" onclick={disableProtection} disabled={vault.busy || !currentPassword}>
-                  {#if vault.busy}
+                <button class="btn btn-sm" type="button" onclick={cancel} disabled={securityPending}>{tr('cancel')}</button>
+                <button class="btn btn-warning btn-sm" type="button" onclick={disableProtection} disabled={securityPending || !currentPassword}>
+                  {#if securityPending}
                     <span class="loading loading-spinner loading-xs"></span>
                   {/if}
                   {tr('turnOff')}
@@ -354,10 +413,10 @@
       <div class="space-y-2 rounded-box border border-error/30 bg-error/5 p-3">
         <label class="grid gap-1.5">
           <span class="text-sm font-medium text-error">{tr('deleteVault')}</span>
-          <input class="input input-sm w-full" bind:value={resetConfirmation} autocomplete="off" placeholder="DELETE" />
+          <input class="input input-sm w-full" bind:value={resetConfirmation} autocomplete="off" placeholder="DELETE" disabled={securityPending} />
         </label>
         <p class="text-xs text-base-content/60">{tr('deleteVaultConfirm')}</p>
-        <button class="btn btn-error btn-block btn-sm" type="button" onclick={resetVault} disabled={vault.busy || resetConfirmation !== 'DELETE'}>
+        <button class="btn btn-error btn-block btn-sm" type="button" onclick={resetVault} disabled={securityPending || resetConfirmation !== 'DELETE'}>
           <Trash2 size={16} aria-hidden="true" />
           {tr('deleteVault')}
         </button>
@@ -365,6 +424,12 @@
     </section>
   </div>
 </div>
+
+<Toast
+  message={settingsToastError || vault.notice}
+  variant={settingsToastError ? 'error' : 'notice'}
+  nonce={vault.noticeKey}
+/>
 
 {#if showBackup}
   <MotionDialog

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -83,7 +83,9 @@ export const MESSAGE_KEYS = [
   'theme',
   'showCountdownSeconds',
   'showCountdownSecondsHint',
-  'codeEntry',
+  'autoSortCodes',
+  'autoSortCodesHint',
+  'settingsSaveFailed',
   'autoPasteCodes',
   'autoPasteCodesHint',
   'system',
@@ -196,7 +198,10 @@ const en: Record<MessageKey, string> = {
   theme: 'Theme',
   showCountdownSeconds: 'Show timer',
   showCountdownSecondsHint: 'Show seconds inside the countdown pie.',
-  codeEntry: 'Code entry',
+  autoSortCodes: 'Auto-sort codes',
+  autoSortCodesHint:
+    'Show likely matches for the current site first when available. Turn this off to arrange codes yourself.',
+  settingsSaveFailed: 'Unable to save settings.',
   autoPasteCodes: 'Auto paste code',
   autoPasteCodesHint:
     'When copying a code, the extension will automatically try to fill it in the 2FA code box on the page. Note: this is best effort and may not always work depending on the page.',
@@ -296,7 +301,10 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
     theme: 'Tema',
     showCountdownSeconds: 'Mostrar temporizador',
     showCountdownSecondsHint: 'Muestra los segundos dentro del indicador circular.',
-    codeEntry: 'Entrada de códigos',
+    autoSortCodes: 'Ordenar códigos automáticamente',
+    autoSortCodesHint:
+      'Cuando estén disponibles, muestra primero las coincidencias probables para el sitio actual. Desactiva esta opción para ordenar los códigos manualmente.',
+    settingsSaveFailed: 'No se pudo guardar la configuración.',
     autoPasteCodes: 'Pegar código automáticamente',
     autoPasteCodesHint:
       'Al hacer clic en un código, lo copia e intenta llenar el campo de código en la página. Algunas páginas pueden impedirlo.',
@@ -393,7 +401,10 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
     theme: 'थीम',
     showCountdownSeconds: 'टाइमर दिखाएं',
     showCountdownSecondsHint: 'काउंटडाउन पाई के अंदर सेकंड दिखाएं।',
-    codeEntry: 'कोड एंट्री',
+    autoSortCodes: 'कोड अपने आप क्रमबद्ध करें',
+    autoSortCodesHint:
+      'उपलब्ध होने पर मौजूदा साइट से संभावित रूप से मेल खाने वाले कोड पहले दिखाएं। कोड खुद क्रमबद्ध करने के लिए इसे बंद करें।',
+    settingsSaveFailed: 'सेटिंग सहेजी नहीं जा सकीं।',
     autoPasteCodes: 'कोड अपने आप पेस्ट करें',
     autoPasteCodesHint:
       'जब आप कोड पर क्लिक करते हैं, यह उसे कॉपी करता है और पेज के कोड बॉक्स में भरने की कोशिश करता है। कुछ पेज इसकी अनुमति नहीं देते।',
@@ -490,7 +501,10 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
     theme: 'السمة',
     showCountdownSeconds: 'إظهار المؤقت',
     showCountdownSecondsHint: 'اعرض الثواني داخل مؤشر العد التنازلي الدائري.',
-    codeEntry: 'إدخال الرموز',
+    autoSortCodes: 'ترتيب الرموز تلقائيًا',
+    autoSortCodesHint:
+      'عند توفرها، اعرض أولًا الرموز التي يُرجح أن تطابق الموقع الحالي. أوقف هذا الخيار لترتيب الرموز بنفسك.',
+    settingsSaveFailed: 'تعذّر حفظ الإعدادات.',
     autoPasteCodes: 'لصق الرمز تلقائيا',
     autoPasteCodesHint:
       'عند النقر على رمز، يتم نسخه ثم محاولة تعبئته في خانة الرمز في الصفحة. قد لا تسمح بعض الصفحات بذلك.',
@@ -587,7 +601,10 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
     theme: 'থিম',
     showCountdownSeconds: 'টাইমার দেখান',
     showCountdownSecondsHint: 'কাউন্টডাউন পাইয়ের ভিতরে সেকেন্ড দেখান।',
-    codeEntry: 'কোড এন্ট্রি',
+    autoSortCodes: 'কোড স্বয়ংক্রিয়ভাবে সাজান',
+    autoSortCodesHint:
+      'উপলভ্য হলে বর্তমান সাইটের সঙ্গে সম্ভাব্য মিল থাকা কোড আগে দেখান। নিজে কোড সাজাতে এটি বন্ধ করুন।',
+    settingsSaveFailed: 'সেটিংস সংরক্ষণ করা যায়নি।',
     autoPasteCodes: 'কোড অটো পেস্ট করুন',
     autoPasteCodesHint:
       'কোডে ক্লিক করলে এটি কপি করে এবং পেজের কোড বক্সে বসানোর চেষ্টা করে। কিছু পেজ এটি অনুমতি নাও দিতে পারে।',
@@ -684,7 +701,10 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
     theme: 'Tema',
     showCountdownSeconds: 'Mostrar temporizador',
     showCountdownSecondsHint: 'Mostra os segundos dentro do indicador circular.',
-    codeEntry: 'Entrada de códigos',
+    autoSortCodes: 'Ordenar códigos automaticamente',
+    autoSortCodesHint:
+      'Quando disponíveis, mostra primeiro as correspondências prováveis para o site atual. Desative para organizar os códigos manualmente.',
+    settingsSaveFailed: 'Não foi possível salvar as configurações.',
     autoPasteCodes: 'Colar código automaticamente',
     autoPasteCodesHint:
       'Ao clicar em um código, ele é copiado e tenta preencher o campo de código na página. Algumas páginas podem bloquear isso.',
@@ -781,7 +801,10 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
     theme: 'Тема',
     showCountdownSeconds: 'Показывать таймер',
     showCountdownSecondsHint: 'Показывает секунды внутри кругового индикатора.',
-    codeEntry: 'Ввод кодов',
+    autoSortCodes: 'Сортировать коды автоматически',
+    autoSortCodesHint:
+      'Когда возможно, сначала показывать вероятные совпадения для текущего сайта. Отключите, чтобы упорядочить коды вручную.',
+    settingsSaveFailed: 'Не удалось сохранить настройки.',
     autoPasteCodes: 'Автовставка кода',
     autoPasteCodesHint:
       'При нажатии на код он копируется и пытается заполнить поле кода на странице. Некоторые страницы могут это блокировать.',
@@ -878,7 +901,10 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
     theme: 'テーマ',
     showCountdownSeconds: 'タイマーを表示',
     showCountdownSecondsHint: 'カウントダウン円の内側に秒数を表示します。',
-    codeEntry: 'コード入力',
+    autoSortCodes: 'コードを自動で並べ替え',
+    autoSortCodesHint:
+      '利用できる場合、現在のサイトに一致する可能性が高いコードを先に表示します。自分で並べ替えるにはオフにします。',
+    settingsSaveFailed: '設定を保存できませんでした。',
     autoPasteCodes: 'コードを自動貼り付け',
     autoPasteCodesHint:
       'コードをクリックするとコピーし、ページのコード入力欄に入れようとします。一部のページでは使えない場合があります。',
@@ -975,7 +1001,10 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
     theme: 'Thème',
     showCountdownSeconds: 'Afficher le minuteur',
     showCountdownSecondsHint: 'Affiche les secondes dans l’indicateur circulaire.',
-    codeEntry: 'Saisie des codes',
+    autoSortCodes: 'Trier les codes automatiquement',
+    autoSortCodesHint:
+      'Lorsque c’est possible, affiche d’abord les correspondances probables pour le site actuel. Désactivez cette option pour organiser les codes vous-même.',
+    settingsSaveFailed: 'Impossible d’enregistrer les paramètres.',
     autoPasteCodes: 'Coller le code automatiquement',
     autoPasteCodesHint:
       'Quand vous cliquez sur un code, il est copié puis l’app essaie de remplir le champ de code sur la page. Certaines pages peuvent le bloquer.',
@@ -1072,7 +1101,10 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
     theme: 'Design',
     showCountdownSeconds: 'Timer anzeigen',
     showCountdownSecondsHint: 'Zeigt die Sekunden im kreisförmigen Countdown an.',
-    codeEntry: 'Codeeingabe',
+    autoSortCodes: 'Codes automatisch sortieren',
+    autoSortCodesHint:
+      'Zeigt, wenn verfügbar, wahrscheinliche Treffer für die aktuelle Website zuerst. Schalte dies aus, um die Codes selbst anzuordnen.',
+    settingsSaveFailed: 'Einstellungen konnten nicht gespeichert werden.',
     autoPasteCodes: 'Code automatisch einfügen',
     autoPasteCodesHint:
       'Wenn du einen Code anklickst, wird er kopiert und in das Codefeld der Seite eingefügt, wenn möglich. Manche Seiten blockieren das.',
@@ -1169,7 +1201,9 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
     theme: '主题',
     showCountdownSeconds: '显示计时器',
     showCountdownSecondsHint: '在圆形倒计时内显示秒数。',
-    codeEntry: '代码输入',
+    autoSortCodes: '自动排序验证码',
+    autoSortCodesHint: '可用时，优先显示可能与当前网站匹配的验证码。关闭后可手动排列验证码。',
+    settingsSaveFailed: '无法保存设置。',
     autoPasteCodes: '自动粘贴代码',
     autoPasteCodesHint:
       '点击代码时会复制它，并尝试填入页面上的代码输入框。有些页面可能不允许这样做。',

--- a/src/lib/state/authenticator.svelte.ts
+++ b/src/lib/state/authenticator.svelte.ts
@@ -37,7 +37,7 @@ import type {
   VaultData,
   VaultEnvelope
 } from '../auth/types';
-import { DEFAULT_SETTINGS } from '../auth/types';
+import { DEFAULT_SETTINGS, normalizeAppSettings } from '../auth/types';
 
 export class AuthenticatorVault {
   initialized = $state(false);
@@ -55,10 +55,16 @@ export class AuthenticatorVault {
   private key: CryptoKey | null = null;
   private encryptedVault: VaultEnvelope | null = null;
   private plainVault: PlainVaultRecord | null = null;
+  private mutationQueue: Promise<void> = Promise.resolve();
+  private codeRefreshRequest = 0;
 
   sortedAccounts = $derived.by(() => [...this.accounts].sort(compareAccountOrder));
 
   async initialize(): Promise<void> {
+    await this.enqueueMutation(() => this.initializeNow());
+  }
+
+  private async initializeNow(): Promise<void> {
     this.busy = true;
     try {
       const stored = await loadStoredVault();
@@ -77,11 +83,18 @@ export class AuthenticatorVault {
   }
 
   async unlock(password: string): Promise<void> {
+    await this.enqueueMutation(() => this.unlockNow(password));
+  }
+
+  private async unlockNow(password: string): Promise<void> {
     if (!this.encryptedVault) {
-      await this.initialize();
+      await this.initializeNow();
     }
     if (!this.encryptedVault) {
       this.error = 'No encrypted vault exists yet.';
+      return;
+    }
+    if (!this.locked) {
       return;
     }
 
@@ -102,62 +115,68 @@ export class AuthenticatorVault {
   }
 
   async lock(): Promise<void> {
-    if (!this.passwordProtected) {
-      this.showNotice('Password protection is off.');
-      return;
-    }
+    await this.enqueueMutation(async () => {
+      if (!this.passwordProtected) {
+        this.showNotice('Password protection is off.');
+        return;
+      }
 
-    await clearVaultSessionKey();
-    this.key = null;
-    this.accounts = [];
-    this.codes = {};
-    this.locked = true;
-    this.showNotice('Vault locked.');
+      await clearVaultSessionKey();
+      this.key = null;
+      this.accounts = [];
+      this.codes = {};
+      this.locked = true;
+      this.showNotice('Vault locked.');
+    });
   }
 
   async addAccount(draft: AccountDraft): Promise<void> {
     const account = createAccount(draft);
-    await this.mergeAccounts([account]);
+    await this.enqueueMutation(() => this.mergeAccounts([account]));
   }
 
   async updateAccount(id: string, draft: Partial<AccountDraft>): Promise<void> {
-    const index = this.accounts.findIndex((account) => account.id === id);
-    if (index === -1) {
-      return;
-    }
-
-    const accounts = [...this.accounts];
-    accounts[index] = updateAccount(accounts[index], draft);
-    await this.persistData({ accounts, settings: this.settings }, 'Account updated.');
-    await this.refreshCodes();
+    const update = { ...draft };
+    await this.enqueueMutation(() => this.updateAccountNow(id, update));
   }
 
   async deleteAccount(id: string): Promise<void> {
-    const accounts = this.accounts.filter((account) => account.id !== id);
-    await this.persistData({ accounts, settings: this.settings }, 'Account removed.');
-    await this.refreshCodes();
+    await this.enqueueMutation(async () => {
+      const accounts = this.accounts.filter((account) => account.id !== id);
+      await this.persistData({ accounts, settings: this.settings }, 'Account removed.');
+      await this.refreshCodes();
+    });
   }
 
   async reorderAccounts(orderedIds: string[]): Promise<void> {
-    const accounts = reorderAccountsById(this.sortedAccounts, orderedIds);
-    if (!accounts) {
-      return;
-    }
+    const requestedOrder = [...orderedIds];
+    await this.enqueueMutation(async () => {
+      if (this.settings.accountSortMode !== 'manual') {
+        return;
+      }
 
-    await this.persistData({ accounts, settings: this.settings });
+      const accounts = reorderAccountsById(this.sortedAccounts, requestedOrder);
+      if (!accounts) {
+        return;
+      }
+
+      await this.persistData({ accounts, settings: this.settings });
+    });
   }
 
   async advanceHotp(id: string): Promise<void> {
-    const account = this.accounts.find((item) => item.id === id);
-    if (!account || account.type !== 'hotp') {
-      return;
-    }
-    await this.updateAccount(id, { counter: account.counter + 1 });
+    await this.enqueueMutation(async () => {
+      const account = this.accounts.find((item) => item.id === id);
+      if (!account || account.type !== 'hotp') {
+        return;
+      }
+      await this.updateAccountNow(id, { counter: account.counter + 1 });
+    });
   }
 
   async importText(text: string): Promise<ImportResult> {
     const result = importAnyText(text);
-    const merged = await this.mergeAccounts(result.accounts);
+    const merged = await this.enqueueMutation(() => this.mergeAccounts(result.accounts));
     return {
       ...result,
       imported: merged.imported,
@@ -167,7 +186,7 @@ export class AuthenticatorVault {
 
   async importEncryptedBackupText(text: string, password: string): Promise<ImportResult> {
     const result = await importEncryptedBackup(text, password);
-    const merged = await this.mergeAccounts(result.accounts);
+    const merged = await this.enqueueMutation(() => this.mergeAccounts(result.accounts));
     return {
       ...result,
       imported: merged.imported,
@@ -175,11 +194,24 @@ export class AuthenticatorVault {
     };
   }
 
-  async replaceSettings(settings: AppSettings): Promise<void> {
-    await this.persistData({ accounts: this.accounts, settings }, 'Settings saved.');
+  async updateSettings(settings: Partial<AppSettings>): Promise<void> {
+    const update = { ...settings };
+    await this.enqueueMutation(() =>
+      this.persistData(
+        {
+          accounts: this.accounts,
+          settings: { ...this.settings, ...update }
+        },
+        'Settings saved.'
+      )
+    );
   }
 
   async changePassword(currentPassword: string, newPassword: string): Promise<void> {
+    await this.enqueueMutation(() => this.changePasswordNow(currentPassword, newPassword));
+  }
+
+  private async changePasswordNow(currentPassword: string, newPassword: string): Promise<void> {
     this.busy = true;
     this.clearStatus();
     try {
@@ -216,6 +248,10 @@ export class AuthenticatorVault {
   }
 
   async removePassword(currentPassword: string): Promise<void> {
+    await this.enqueueMutation(() => this.removePasswordNow(currentPassword));
+  }
+
+  private async removePasswordNow(currentPassword: string): Promise<void> {
     if (!this.passwordProtected) {
       this.showNotice('Password protection is already off.');
       return;
@@ -255,6 +291,10 @@ export class AuthenticatorVault {
   }
 
   async resetVault(): Promise<void> {
+    await this.enqueueMutation(() => this.resetVaultNow());
+  }
+
+  private async resetVaultNow(): Promise<void> {
     this.busy = true;
     this.clearStatus();
     try {
@@ -277,12 +317,17 @@ export class AuthenticatorVault {
   }
 
   async refreshCodes(now = Date.now()): Promise<void> {
-    if (this.locked || this.accounts.length === 0) {
+    const request = ++this.codeRefreshRequest;
+    const accounts = this.accounts;
+    if (this.locked || accounts.length === 0) {
       this.codes = {};
       return;
     }
 
-    const entries = await Promise.all(this.accounts.map((account) => generateOtpCode(account, now)));
+    const entries = await Promise.all(accounts.map((account) => generateOtpCode(account, now)));
+    if (request !== this.codeRefreshRequest || this.locked || this.accounts !== accounts) {
+      return;
+    }
     this.codes = Object.fromEntries(entries.map((entry) => [entry.accountId, entry]));
   }
 
@@ -336,10 +381,30 @@ export class AuthenticatorVault {
       this.key = unlocked.key;
       this.applyUnlockedData(unlocked.data);
       this.locked = false;
-      await this.refreshCodes();
     } catch {
       await clearVaultSessionKey();
     }
+  }
+
+  private enqueueMutation<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.mutationQueue.then(() => operation());
+    this.mutationQueue = result.then(
+      () => undefined,
+      () => undefined
+    );
+    return result;
+  }
+
+  private async updateAccountNow(id: string, draft: Partial<AccountDraft>): Promise<void> {
+    const index = this.accounts.findIndex((account) => account.id === id);
+    if (index === -1) {
+      return;
+    }
+
+    const accounts = [...this.accounts];
+    accounts[index] = updateAccount(accounts[index], draft);
+    await this.persistData({ accounts, settings: this.settings }, 'Account updated.');
+    await this.refreshCodes();
   }
 
   private async mergeAccounts(incoming: AuthenticatorAccount[]): Promise<{ imported: number; skipped: number }> {
@@ -372,7 +437,6 @@ export class AuthenticatorVault {
 
       const envelope = await encryptVaultData(normalizedData, this.key, this.encryptedVault);
       await saveStoredVault(envelope);
-      await this.saveSessionKey(this.key, envelope);
       this.encryptedVault = envelope;
       this.plainVault = null;
     } else {
@@ -397,7 +461,7 @@ export class AuthenticatorVault {
 
   private applyUnlockedData(data: VaultData): void {
     this.accounts = normalizeAccountOrder(data.accounts);
-    this.settings = { ...DEFAULT_SETTINGS, ...data.settings };
+    this.settings = normalizeAppSettings(data.settings);
   }
 
   private getCurrentData(): VaultData {
@@ -418,12 +482,8 @@ function normalizeVaultData(data: VaultData): VaultData {
   // instead of Svelte state proxies.
   return {
     accounts: normalizeAccountOrder(data.accounts),
-    settings: normalizeSettings(data.settings)
+    settings: normalizeAppSettings(data.settings)
   };
-}
-
-function normalizeSettings(settings: Partial<AppSettings> | undefined): AppSettings {
-  return { ...DEFAULT_SETTINGS, ...settings };
 }
 
 function getErrorMessage(error: unknown): string {

--- a/test/auth/accountRanking.test.ts
+++ b/test/auth/accountRanking.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, test } from 'vitest';
+import {
+  getAccountPageMatchScore,
+  rankAccountsForPage
+} from '../../src/lib/auth/accountRanking';
+import { SITE_IDENTITY_OVERRIDES } from '../../src/lib/auth/accountSiteMetadata';
+import type { AuthenticatorAccount } from '../../src/lib/auth/types';
+
+describe('contextual account ranking', () => {
+  test('puts an issuer matching the current site first', () => {
+    const accounts = [account('GitHub'), account('Instagram'), account('Example')];
+
+    expect(labels(rankAccountsForPage(accounts, { hostname: 'www.instagram.com' }))).toEqual([
+      'Instagram',
+      'GitHub',
+      'Example'
+    ]);
+  });
+
+  test('matches compact names, punctuation, diacritics, and public suffixes', () => {
+    const accounts = [account('Example'), account('Bank of America'), account('Digital Océan')];
+
+    expect(
+      labels(rankAccountsForPage(accounts, { hostname: 'secure.bank-of-america.co.uk' }))
+    ).toEqual(['Bank of America', 'Example', 'Digital Océan']);
+    expect(
+      labels(rankAccountsForPage(accounts, { hostname: 'login.digital-ocean.com' }))
+    ).toEqual(['Digital Océan', 'Example', 'Bank of America']);
+  });
+
+  test('supports historical and shared-brand aliases in both directions', () => {
+    const twitter = account('Twitter');
+    const x = account('X');
+    const openAi = account('OpenAI');
+
+    expect(rankAccountsForPage([openAi, twitter], { hostname: 'x.com' })[0]).toBe(twitter);
+    expect(rankAccountsForPage([openAi, x], { hostname: 'twitter.com' })[0]).toBe(x);
+    expect(rankAccountsForPage([twitter, openAi], { hostname: 'chatgpt.com' })[0]).toBe(openAi);
+  });
+
+  test('covers popular rebrands, shared accounts, and domain-name mismatches', () => {
+    const cases = [
+      ['icloud.com', 'Apple ID'],
+      ['accounts.firefox.com', 'Mozilla Account'],
+      ['ubisoft.com', 'Uplay'],
+      ['tutanota.com', 'Tuta'],
+      ['goto.com', 'LogMeIn'],
+      ['gmail.com', 'Google'],
+      ['fitbit.com', 'Google'],
+      ['office.com', 'Microsoft'],
+      ['threads.com', 'Instagram'],
+      ['trello.com', 'Atlassian'],
+      ['behance.net', 'Adobe ID'],
+      ['audible.com', 'Amazon'],
+      ['quickbooks.com', 'Intuit'],
+      ['claude.ai', 'Anthropic'],
+      ['steampowered.com', 'Steam'],
+      ['valorant.com', 'Riot Games'],
+      ['npmjs.com', 'npm'],
+      ['duosecurity.com', 'Cisco Duo'],
+      ['keepersecurity.com', 'Keeper'],
+      ['mi.com', 'Xiaomi'],
+      ['wikipedia.org', 'Wikimedia']
+    ] as const;
+
+    for (const [hostname, issuer] of cases) {
+      expect(
+        getAccountPageMatchScore(account(issuer), { hostname }),
+        `${issuer} should match ${hostname}`
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  test('keeps sibling products isolated when only their account provider is shared', () => {
+    expect(getAccountPageMatchScore(account('YouTube'), { hostname: 'gmail.com' })).toBe(0);
+    expect(getAccountPageMatchScore(account('Bitbucket'), { hostname: 'trello.com' })).toBe(0);
+    expect(getAccountPageMatchScore(account('TurboTax'), { hostname: 'quickbooks.com' })).toBe(0);
+    expect(getAccountPageMatchScore(account('Instagram'), { hostname: 'facebook.com' })).toBe(0);
+    expect(getAccountPageMatchScore(account('Meta'), { hostname: 'instagram.com' })).toBe(0);
+    expect(getAccountPageMatchScore(account('Dropbox'), { hostname: 'hellosign.com' })).toBe(0);
+    expect(getAccountPageMatchScore(account('Cisco'), { hostname: 'duosecurity.com' })).toBe(0);
+    expect(getAccountPageMatchScore(account('Microsoft'), { hostname: 'github.com' })).toBe(0);
+  });
+
+  test('keeps override metadata normalized and free of duplicate domains', () => {
+    const domains = SITE_IDENTITY_OVERRIDES.flatMap((entry) => [...entry.domains]);
+
+    expect(new Set(domains).size).toBe(domains.length);
+    for (const entry of SITE_IDENTITY_OVERRIDES) {
+      expect(entry.domains.length).toBeGreaterThan(0);
+      expect(entry.names.length).toBeGreaterThan(0);
+      for (const domain of entry.domains) {
+        expect(domain).toBe(domain.toLowerCase());
+        expect(domain).toMatch(/^[a-z0-9.-]+$/);
+        expect(domain).not.toMatch(/^\.|\.$/);
+      }
+    }
+  });
+
+  test('lets specific overrides replace a generic parent brand', () => {
+    const other = account('Example');
+    const amazon = account('Amazon');
+    const aws = account('Amazon Web Services');
+
+    expect(
+      rankAccountsForPage([other, amazon, aws], { hostname: 'signin.aws.amazon.com' })
+    ).toEqual([aws, other, amazon]);
+    expect(getAccountPageMatchScore(amazon, { hostname: 'signin.aws.amazon.com' })).toBe(0);
+  });
+
+  test('uses a label when the issuer is missing or generic', () => {
+    const blankIssuer = account('', 'Instagram · alice');
+    const genericIssuer = account('2FA', 'Instagram backup');
+    const other = account('GitHub');
+
+    expect(rankAccountsForPage([other, blankIssuer], { hostname: 'instagram.com' })[0]).toBe(blankIssuer);
+    expect(rankAccountsForPage([other, genericIssuer], { hostname: 'instagram.com' })[0]).toBe(genericIssuer);
+  });
+
+  test('can use a non-email label as a weaker secondary signal', () => {
+    const labeled = account('Personal vault', 'Instagram alice');
+    const other = account('GitHub');
+
+    expect(rankAccountsForPage([other, labeled], { hostname: 'instagram.com' })[0]).toBe(labeled);
+  });
+
+  test('weights issuer, fallback label, and secondary label matches predictably', () => {
+    const issuerMatch = account('Instagram', 'alice');
+    const fallbackLabelMatch = account('', 'Instagram bob');
+    const secondaryLabelMatch = account('Personal vault', 'Instagram carol');
+    const context = { hostname: 'instagram.com' };
+
+    expect(getAccountPageMatchScore(issuerMatch, context)).toBeGreaterThan(
+      getAccountPageMatchScore(fallbackLabelMatch, context)
+    );
+    expect(getAccountPageMatchScore(fallbackLabelMatch, context)).toBeGreaterThan(
+      getAccountPageMatchScore(secondaryLabelMatch, context)
+    );
+  });
+
+  test('does not trust lookalike domains or page titles on unrelated domains', () => {
+    const accounts = [account('GitHub'), account('Instagram')];
+    const instagram = accounts[1];
+
+    expect(
+      getAccountPageMatchScore(instagram, {
+        hostname: 'instagram-login.example.com',
+        title: 'Instagram – Sign in'
+      })
+    ).toBe(0);
+    expect(getAccountPageMatchScore(instagram, { hostname: 'instagram.com.evil.test' })).toBe(0);
+    expect(
+      labels(
+        rankAccountsForPage(accounts, {
+          hostname: 'example.com',
+          title: 'Instagram – Sign in'
+        })
+      )
+    ).toEqual(['GitHub', 'Instagram']);
+  });
+
+  test('ignores account email domains as service names', () => {
+    const github = account('GitHub', 'alice@instagram.com');
+    const example = account('Example');
+
+    expect(rankAccountsForPage([github, example], { hostname: 'instagram.com' })).toEqual([
+      github,
+      example
+    ]);
+  });
+
+  test('uses an email domain only when no useful issuer is available', () => {
+    const blankIssuer = account('', 'alice@instagram.com');
+    const other = account('GitHub');
+
+    expect(rankAccountsForPage([other, blankIssuer], { hostname: 'instagram.com' })[0]).toBe(blankIssuer);
+  });
+
+  test('does not infer brands from privately controlled hosting subdomains', () => {
+    const accounts = [account('GitHub'), account('Instagram')];
+
+    expect(rankAccountsForPage(accounts, { hostname: 'instagram.github.io' })).toEqual(accounts);
+    expect(
+      rankAccountsForPage([account('Shopify'), account('Vercel')], {
+        hostname: 'shop.example.myshopify.com'
+      }).map((item) => item.issuer)
+    ).toEqual(['Shopify', 'Vercel']);
+    expect(getAccountPageMatchScore(account('Cloudflare'), { hostname: 'project.pages.dev' })).toBe(0);
+    expect(getAccountPageMatchScore(account('Vercel'), { hostname: 'project.vercel.app' })).toBe(0);
+  });
+
+  test('supports exact local and IP service labels', () => {
+    const local = account('localhost');
+    const router = account('192.168.1.1');
+    const other = account('Example');
+
+    expect(rankAccountsForPage([other, local], { hostname: 'localhost' })[0]).toBe(local);
+    expect(rankAccountsForPage([other, router], { hostname: '192.168.1.1' })[0]).toBe(router);
+  });
+
+  test('avoids incidental short-domain matches while supporting exact dotted brands', () => {
+    const appleId = account('Apple ID');
+    const idMe = account('ID.me');
+    const creativeAi = account('Creative AI tools');
+    const ai = account('AI');
+
+    expect(getAccountPageMatchScore(appleId, { hostname: 'id.me' })).toBe(0);
+    expect(getAccountPageMatchScore(idMe, { hostname: 'id.me' })).toBeGreaterThan(0);
+    expect(getAccountPageMatchScore(creativeAi, { hostname: 'ai.com' })).toBe(0);
+    expect(getAccountPageMatchScore(ai, { hostname: 'ai.com' })).toBeGreaterThan(0);
+  });
+
+  test('requires short and noise-heavy aliases to match the full account name', () => {
+    expect(getAccountPageMatchScore(account('Mi'), { hostname: 'mi.com' })).toBeGreaterThan(0);
+    expect(getAccountPageMatchScore(account('Mi Banco'), { hostname: 'mi.com' })).toBe(0);
+    expect(
+      getAccountPageMatchScore(account('Login.gov'), { hostname: 'login.gov' })
+    ).toBeGreaterThan(0);
+    expect(getAccountPageMatchScore(account('Gov.uk'), { hostname: 'login.gov' })).toBe(0);
+  });
+
+  test('does not guess an expanded issuer from a generic domain acronym', () => {
+    expect(getAccountPageMatchScore(account('ABC'), { hostname: 'abc.com' })).toBeGreaterThan(0);
+    expect(getAccountPageMatchScore(account('Apple Business Connect'), { hostname: 'abc.com' })).toBe(0);
+  });
+
+  test('keeps intentional parent identities on more-specific overrides', () => {
+    expect(getAccountPageMatchScore(account('Azure'), { hostname: 'dev.azure.com' })).toBeGreaterThan(0);
+    expect(
+      getAccountPageMatchScore(account('Visual Studio'), { hostname: 'visualstudio.com' })
+    ).toBeGreaterThan(0);
+    expect(getAccountPageMatchScore(account('Live'), { hostname: 'onedrive.live.com' })).toBeGreaterThan(0);
+  });
+
+  test('uses titles only to reinforce an existing hostname match', () => {
+    const instagram = account('Instagram');
+    const withoutTitle = getAccountPageMatchScore(instagram, { hostname: 'instagram.com' });
+    const withTitle = getAccountPageMatchScore(instagram, {
+      hostname: 'instagram.com',
+      title: 'Sign in to Instagram'
+    });
+
+    expect(withTitle).toBeGreaterThan(withoutTitle);
+  });
+
+  test('retains manual order for equal matches and all unmatched accounts', () => {
+    const firstInstagram = account('Instagram', 'alice');
+    const github = account('GitHub');
+    const secondInstagram = account('Instagram', 'bob');
+    const example = account('Example');
+
+    expect(
+      rankAccountsForPage([github, firstInstagram, example, secondInstagram], {
+        hostname: 'instagram.com'
+      })
+    ).toEqual([firstInstagram, secondInstagram, github, example]);
+  });
+
+  test('falls back safely and never mutates the incoming account array', () => {
+    const accounts = [account('GitHub'), account('Instagram')];
+    const snapshot = [...accounts];
+
+    expect(rankAccountsForPage(accounts, null)).toEqual(snapshot);
+    expect(rankAccountsForPage(accounts, { hostname: 'not a hostname' })).toEqual(snapshot);
+    expect(rankAccountsForPage(accounts, { hostname: 'chrome://extensions' })).toEqual(snapshot);
+    expect(accounts).toEqual(snapshot);
+  });
+});
+
+function account(issuer: string, label = issuer): AuthenticatorAccount {
+  return {
+    id: crypto.randomUUID(),
+    issuer,
+    label,
+    secret: 'JBSWY3DPEHPK3PXP',
+    type: 'totp',
+    algorithm: 'SHA-1',
+    digits: 6,
+    period: 30,
+    counter: 0,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z'
+  };
+}
+
+function labels(accounts: AuthenticatorAccount[]): string[] {
+  return accounts.map((item) => item.issuer || item.label);
+}

--- a/test/auth/backup.test.ts
+++ b/test/auth/backup.test.ts
@@ -10,7 +10,8 @@ const validVaultData: VaultData = {
     language: 'en',
     theme: 'light',
     showCountdownSeconds: false,
-    autoPasteCodes: false
+    autoPasteCodes: false,
+    accountSortMode: 'manual'
   }
 };
 

--- a/test/auth/vaultImport.test.ts
+++ b/test/auth/vaultImport.test.ts
@@ -27,6 +27,19 @@ describe('importTextIntoStoredVault', () => {
     expect(stored.data.accounts).toHaveLength(1);
     expect(stored.data.accounts[0].label).toBe('alice@example.com');
     expect(stored.data.accounts[0].sortOrder).toBe(0);
+    expect(stored.data.settings.accountSortMode).toBe('contextual');
+  });
+
+  test('preserves a manual sorting preference when importing into a plain vault', async () => {
+    const vault = new AuthenticatorVault();
+    await vault.initialize();
+    await vault.updateSettings({ accountSortMode: 'manual' });
+
+    await importTextIntoStoredVault(ALICE_URI);
+
+    const reopened = new AuthenticatorVault();
+    await reopened.initialize();
+    expect(reopened.settings.accountSortMode).toBe('manual');
   });
 
   test('rejects malformed JSON account imports before storage', async () => {
@@ -103,10 +116,15 @@ describe('importTextIntoStoredVault', () => {
   });
 
   test('imports into an encrypted vault while the session key is available', async () => {
+    const { sessionStorage } = installMemoryStorage();
     const vault = new AuthenticatorVault();
     await vault.initialize();
     await vault.importText(ALICE_URI);
+    await vault.updateSettings({ accountSortMode: 'contextual' });
     await vault.changePassword('', PASSWORD);
+    sessionStorage.setItem = () => {
+      throw new Error('session failed');
+    };
 
     const result = await importTextIntoStoredVault(BOB_URI);
 
@@ -116,6 +134,7 @@ describe('importTextIntoStoredVault', () => {
     await reopened.initialize();
     expect(reopened.locked).toBe(false);
     expect(reopened.passwordProtected).toBe(true);
+    expect(reopened.settings.accountSortMode).toBe('contextual');
     expect(reopened.sortedAccounts.map((account) => account.label)).toEqual([
       'alice@example.com',
       'bob@example.com'

--- a/test/auth/vaultRecords.test.ts
+++ b/test/auth/vaultRecords.test.ts
@@ -8,7 +8,8 @@ const vaultData: VaultData = {
     language: 'en',
     theme: 'light',
     showCountdownSeconds: false,
-    autoPasteCodes: false
+    autoPasteCodes: false,
+    accountSortMode: 'manual'
   }
 };
 

--- a/test/helpers/storage.ts
+++ b/test/helpers/storage.ts
@@ -46,8 +46,10 @@ export function installMemoryStorage(): { localStorage: MemoryStorage; sessionSt
   return { localStorage, sessionStorage };
 }
 
-export function installStructuredCloneChromeStorage(): void {
-  const local = createChromeStorageArea();
+export function installStructuredCloneChromeStorage(
+  { localWriteDelayMs = 0 }: { localWriteDelayMs?: number } = {}
+): void {
+  const local = createChromeStorageArea(localWriteDelayMs);
   const session = createChromeStorageArea();
 
   Object.defineProperty(globalThis, 'chrome', {
@@ -64,7 +66,7 @@ export function installStructuredCloneChromeStorage(): void {
   });
 }
 
-function createChromeStorageArea() {
+function createChromeStorageArea(writeDelayMs = 0) {
   const values = new Map<string, unknown>();
 
   return {
@@ -74,10 +76,17 @@ function createChromeStorageArea() {
     set(items: Record<string, unknown>, callback: () => void): void {
       // Firefox extension storage structured-clones values and rejects proxies.
       const cloned = structuredClone(items) as Record<string, unknown>;
-      for (const [key, value] of Object.entries(cloned)) {
-        values.set(key, value);
+      const commit = () => {
+        for (const [key, value] of Object.entries(cloned)) {
+          values.set(key, value);
+        }
+        callback();
+      };
+      if (writeDelayMs > 0) {
+        setTimeout(commit, writeDelayMs);
+      } else {
+        commit();
       }
-      callback();
     },
     remove(key: string, callback: () => void): void {
       values.delete(key);

--- a/test/state/authenticator.test.ts
+++ b/test/state/authenticator.test.ts
@@ -1,7 +1,11 @@
-import { beforeEach, describe, expect, test } from 'vitest';
-import { loadStoredVault } from '../../src/lib/auth/storage';
-import type { AuthenticatorAccount } from '../../src/lib/auth/types';
-import { isEncryptedVaultRecord, isPlainVaultRecord } from '../../src/lib/auth/vaultRecords';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { loadStoredVault, saveStoredVault } from '../../src/lib/auth/storage';
+import type { AppSettings, AuthenticatorAccount } from '../../src/lib/auth/types';
+import {
+  createPlainVaultRecord,
+  isEncryptedVaultRecord,
+  isPlainVaultRecord
+} from '../../src/lib/auth/vaultRecords';
 import { AuthenticatorVault } from '../../src/lib/state/authenticator.svelte';
 import { installMemoryStorage, installStructuredCloneChromeStorage } from '../helpers/storage';
 
@@ -98,6 +102,7 @@ describe('AuthenticatorVault persistence and locking', () => {
     const vault = new AuthenticatorVault();
     await vault.initialize();
     await vault.importText(MULTI_IMPORT);
+    await vault.updateSettings({ accountSortMode: 'manual' });
     const noticeBeforeReorder = vault.notice;
 
     const byLabel = accountsByLabel(vault.sortedAccounts);
@@ -130,6 +135,7 @@ describe('AuthenticatorVault persistence and locking', () => {
     const vault = new AuthenticatorVault();
     await vault.initialize();
     await vault.importText(MULTI_IMPORT);
+    await vault.updateSettings({ accountSortMode: 'manual' });
 
     const byLabel = accountsByLabel(vault.sortedAccounts);
     await vault.reorderAccounts([
@@ -149,6 +155,7 @@ describe('AuthenticatorVault persistence and locking', () => {
     const vault = new AuthenticatorVault();
     await vault.initialize();
     await vault.importText(MULTI_IMPORT);
+    await vault.updateSettings({ accountSortMode: 'manual' });
     const originalIds = vault.sortedAccounts.map((account) => account.id);
 
     await vault.reorderAccounts([originalIds[1], originalIds[0]]);
@@ -165,6 +172,7 @@ describe('AuthenticatorVault persistence and locking', () => {
     const vault = new AuthenticatorVault();
     await vault.initialize();
     await vault.importText(MULTI_IMPORT);
+    await vault.updateSettings({ accountSortMode: 'manual' });
 
     const byLabel = accountsByLabel(vault.sortedAccounts);
     await vault.reorderAccounts([
@@ -189,11 +197,12 @@ describe('AuthenticatorVault persistence and locking', () => {
 
     expect(vault.settings.theme).toBe('system');
 
-    await vault.replaceSettings({
+    await vault.updateSettings({
       language: 'fr',
       theme: 'dark',
       showCountdownSeconds: true,
-      autoPasteCodes: true
+      autoPasteCodes: true,
+      accountSortMode: 'contextual'
     });
 
     expect(vault.hasVault).toBe(true);
@@ -207,12 +216,148 @@ describe('AuthenticatorVault persistence and locking', () => {
     expect(reopened.settings.theme).toBe('dark');
     expect(reopened.settings.showCountdownSeconds).toBe(true);
     expect(reopened.settings.autoPasteCodes).toBe(true);
+    expect(reopened.settings.accountSortMode).toBe('contextual');
+  });
+
+  test('enables contextual sorting for legacy settings without a saved preference', async () => {
+    await saveStoredVault(
+      createPlainVaultRecord({
+        accounts: [],
+        settings: {
+          language: 'en',
+          theme: 'system',
+          showCountdownSeconds: false,
+          autoPasteCodes: false
+        } as AppSettings
+      })
+    );
+
+    const vault = new AuthenticatorVault();
+    await vault.initialize();
+
+    expect(vault.settings.accountSortMode).toBe('contextual');
+  });
+
+  test('merges concurrent settings updates without losing changes', async () => {
+    installStructuredCloneChromeStorage();
+    const vault = new AuthenticatorVault();
+    await vault.initialize();
+
+    await Promise.all([
+      vault.updateSettings({ theme: 'dark' }),
+      vault.updateSettings({ showCountdownSeconds: true }),
+      vault.updateSettings({ accountSortMode: 'contextual' })
+    ]);
+    await Promise.all([
+      vault.updateSettings({ autoPasteCodes: true }),
+      vault.updateSettings({ autoPasteCodes: false }),
+      vault.updateSettings({ autoPasteCodes: true })
+    ]);
+
+    expect(vault.settings.theme).toBe('dark');
+    expect(vault.settings.showCountdownSeconds).toBe(true);
+    expect(vault.settings.accountSortMode).toBe('contextual');
+    expect(vault.settings.autoPasteCodes).toBe(true);
+
+    const reopened = new AuthenticatorVault();
+    await reopened.initialize();
+    expect(reopened.settings.theme).toBe('dark');
+    expect(reopened.settings.showCountdownSeconds).toBe(true);
+    expect(reopened.settings.accountSortMode).toBe('contextual');
+    expect(reopened.settings.autoPasteCodes).toBe(true);
+  });
+
+  test('finishes a pending settings write before resetting the vault', async () => {
+    installStructuredCloneChromeStorage({ localWriteDelayMs: 10 });
+    const vault = new AuthenticatorVault();
+    await vault.initialize();
+
+    const settingsWrite = vault.updateSettings({ theme: 'dark' });
+    const reset = vault.resetVault();
+    await Promise.all([settingsWrite, reset]);
+
+    expect(vault.hasVault).toBe(false);
+    expect(vault.settings).toEqual({
+      language: 'en',
+      theme: 'system',
+      showCountdownSeconds: false,
+      autoPasteCodes: false,
+      accountSortMode: 'contextual'
+    });
+    expect(await loadStoredVault()).toBeNull();
+  });
+
+  test('finishes a pending encrypted settings write before locking', async () => {
+    installStructuredCloneChromeStorage({ localWriteDelayMs: 10 });
+    const vault = new AuthenticatorVault();
+    await vault.initialize();
+    await vault.importText(OTPAUTH_URI);
+    await vault.changePassword('', PASSWORD);
+
+    const settingsWrite = vault.updateSettings({ theme: 'dark' });
+    const lock = vault.lock();
+    await Promise.all([settingsWrite, lock]);
+
+    expect(vault.locked).toBe(true);
+    expect(vault.accounts).toHaveLength(0);
+
+    const reopened = new AuthenticatorVault();
+    await reopened.initialize();
+    expect(reopened.locked).toBe(true);
+    await reopened.unlock(PASSWORD);
+    expect(reopened.settings.theme).toBe('dark');
+  });
+
+  test('serializes unlock and lock in invocation order', async () => {
+    const vault = new AuthenticatorVault();
+    await vault.initialize();
+    await vault.importText(OTPAUTH_URI);
+    await vault.changePassword('', PASSWORD);
+    await vault.lock();
+
+    await Promise.all([vault.unlock(PASSWORD), vault.lock()]);
+
+    expect(vault.locked).toBe(true);
+    expect(vault.accounts).toHaveLength(0);
+    const reopened = new AuthenticatorVault();
+    await reopened.initialize();
+    expect(reopened.locked).toBe(true);
+  });
+
+  test('preserves manual order while contextual sorting is enabled', async () => {
+    installStructuredCloneChromeStorage();
+    const vault = new AuthenticatorVault();
+    await vault.initialize();
+    await vault.importText(MULTI_IMPORT);
+    await vault.updateSettings({ accountSortMode: 'manual' });
+
+    const byLabel = accountsByLabel(vault.sortedAccounts);
+    await vault.reorderAccounts([
+      byLabel.get('carol@example.com')?.id ?? '',
+      byLabel.get('alice@example.com')?.id ?? '',
+      byLabel.get('bob@example.com')?.id ?? ''
+    ]);
+    const manualIds = vault.sortedAccounts.map((account) => account.id);
+
+    await vault.updateSettings({ accountSortMode: 'contextual' });
+    await vault.reorderAccounts([...manualIds].reverse());
+
+    expect(vault.sortedAccounts.map((account) => account.id)).toEqual(manualIds);
+
+    const reopened = new AuthenticatorVault();
+    await reopened.initialize();
+    expect(reopened.settings.accountSortMode).toBe('contextual');
+    expect(reopened.sortedAccounts.map((account) => account.id)).toEqual(manualIds);
+
+    await reopened.updateSettings({ accountSortMode: 'manual' });
+    expect(reopened.sortedAccounts.map((account) => account.id)).toEqual(manualIds);
   });
 
   test('enables password protection and restores unlocked state for the extension session', async () => {
     const vault = new AuthenticatorVault();
     await vault.initialize();
     await vault.importText(OTPAUTH_URI);
+    await vault.updateSettings({ accountSortMode: 'contextual' });
     await vault.changePassword('', PASSWORD);
 
     expect(vault.error).toBe('');
@@ -226,6 +371,7 @@ describe('AuthenticatorVault persistence and locking', () => {
     expect(reopened.locked).toBe(false);
     expect(reopened.passwordProtected).toBe(true);
     expect(reopened.accounts).toHaveLength(1);
+    expect(reopened.settings.accountSortMode).toBe('contextual');
   });
 
   test('failed password setup does not switch live state to password protected', async () => {
@@ -262,6 +408,53 @@ describe('AuthenticatorVault persistence and locking', () => {
     expect(vault.locked).toBe(false);
     expect(vault.accounts).toHaveLength(1);
     expect(isEncryptedVaultRecord(await loadStoredVault())).toBe(true);
+  });
+
+  test('ordinary encrypted writes do not rewrite the unchanged session key', async () => {
+    const { sessionStorage } = installMemoryStorage();
+    const vault = new AuthenticatorVault();
+    await vault.initialize();
+    await vault.importText(OTPAUTH_URI);
+    await vault.changePassword('', PASSWORD);
+    sessionStorage.setItem = () => {
+      throw new Error('session failed');
+    };
+
+    await expect(vault.updateSettings({ theme: 'dark' })).resolves.toBeUndefined();
+
+    expect(vault.settings.theme).toBe('dark');
+    const reopened = new AuthenticatorVault();
+    await reopened.initialize();
+    expect(reopened.locked).toBe(false);
+    expect(reopened.settings.theme).toBe('dark');
+  });
+
+  test('does not publish a stale code after the vault is locked', async () => {
+    const vault = new AuthenticatorVault();
+    await vault.initialize();
+    await vault.importText(OTPAUTH_URI);
+    await vault.changePassword('', PASSWORD);
+
+    let releaseSign = () => {};
+    let markSignStarted = () => {};
+    const signReleased = new Promise<void>((resolve) => (releaseSign = resolve));
+    const signStarted = new Promise<void>((resolve) => (markSignStarted = resolve));
+    const originalSign = crypto.subtle.sign.bind(crypto.subtle);
+    const sign = vi.spyOn(crypto.subtle, 'sign').mockImplementation(async (algorithm, key, data) => {
+      markSignStarted();
+      await signReleased;
+      return originalSign(algorithm, key, data);
+    });
+
+    const refresh = vault.refreshCodes();
+    await signStarted;
+    await vault.lock();
+    releaseSign();
+    await refresh;
+    sign.mockRestore();
+
+    expect(vault.locked).toBe(true);
+    expect(vault.codes).toEqual({});
   });
 
   test('manual lock clears the session unlock and requires the password again', async () => {


### PR DESCRIPTION
This PR adds an option to sort 2FA codes by codes most likely to apply to the site you're currently viewing. So when this option is enabled, 2FA codes that belong to the website you're currently browsing will be displayed first (best effort as detection is based off metadata).

Closes #6