### PR TITLE
Hide unmatched codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Browser extension for generating and managing two-factor authentication codes.
 
 - Generate TOTP, HOTP, and Steam-style 2FA codes.
 - Add accounts from QR images, page QR scans, pasted otpauth text, or manual entry.
-- Search, copy, manually reorder accounts, or prioritize likely codes for the current site.
+- Search, copy, manually reorder accounts, or focus on likely codes for the current site with one-click access to the rest.
 - Import/export otpauth text and encrypted backups.
 - Optional local vault password protection.
 - Local-first storage with no account service.

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -124,7 +124,8 @@
   let pageScanError = $state('');
   let pageContext = $state.raw<PageContext | null>(null);
   let pageContextReady = $state(false);
-  let allCodesRevealed = $state(false);
+  let showAllCodesOverride = $state<boolean | null>(null);
+  let alwaysShowAllCodesPending = $state<boolean | null>(null);
   let pageContextRequest = 0;
   let browserWindowId: number | undefined;
 
@@ -133,10 +134,13 @@
     getAccountPageRanking(vault.sortedAccounts, manualSort ? null : pageContext)
   );
   const orderedAccounts = $derived.by(() => dragAccounts ?? pageRanking.accounts);
+  const alwaysShowAllCodes = $derived(
+    alwaysShowAllCodesPending ?? vault.settings.alwaysShowAllCodes
+  );
   const accountListView = $derived(
     getAccountListView(orderedAccounts, pageRanking.suggestedAccountIds, {
       query,
-      revealAll: allCodesRevealed
+      revealAll: showAllCodesOverride ?? alwaysShowAllCodes
     })
   );
   const filteredAccounts = $derived(accountListView.accounts);
@@ -265,11 +269,61 @@
     }
   }
 
+  async function setAlwaysShowAllCodes(input: HTMLInputElement) {
+    if (alwaysShowAllCodesPending !== null) {
+      input.checked = alwaysShowAllCodes;
+      return;
+    }
+
+    const enabled = input.checked;
+    const previousOverride = showAllCodesOverride;
+    showAllCodesOverride = null;
+    alwaysShowAllCodesPending = enabled;
+    try {
+      await vault.updateSettings({ alwaysShowAllCodes: enabled });
+      showAllCodesOverride = null;
+    } catch (error) {
+      showAllCodesOverride = previousOverride;
+      vault.error = getErrorMessage(error, tr('settingsSaveFailed'));
+    } finally {
+      alwaysShowAllCodesPending = null;
+      input.checked = vault.settings.alwaysShowAllCodes;
+    }
+  }
+
+  async function toggleContextualAccountView() {
+    if (alwaysShowAllCodesPending !== null) {
+      return;
+    }
+
+    if (accountListView.contextualAction === 'showAll') {
+      showAllCodesOverride = true;
+      return;
+    }
+
+    const previousOverride = showAllCodesOverride;
+    showAllCodesOverride = false;
+    if (!vault.settings.alwaysShowAllCodes) {
+      return;
+    }
+
+    alwaysShowAllCodesPending = false;
+    try {
+      await vault.updateSettings({ alwaysShowAllCodes: false });
+      showAllCodesOverride = null;
+    } catch (error) {
+      showAllCodesOverride = previousOverride;
+      vault.error = getErrorMessage(error, tr('settingsSaveFailed'));
+    } finally {
+      alwaysShowAllCodesPending = null;
+    }
+  }
+
   async function refreshPageContext(clearCurrent = true) {
     const request = ++pageContextRequest;
     if (clearCurrent) {
       pageContext = null;
-      allCodesRevealed = false;
+      showAllCodesOverride = null;
     }
     if (vault.settings.accountSortMode === 'manual' || !hasRuntimeMessaging()) {
       pageContext = null;
@@ -284,7 +338,7 @@
       if (request === pageContextRequest) {
         const nextContext = parsePageContext(response.pageContext);
         if (nextContext?.hostname !== pageContext?.hostname) {
-          allCodesRevealed = false;
+          showAllCodesOverride = null;
         }
         pageContext = nextContext;
       }
@@ -1014,14 +1068,14 @@
                 {/each}
               </ul>
               {#if accountListView.contextualAction}
-                <div class="px-3 py-3">
+                <div class="space-y-1 px-3 pb-2 pt-3">
                   <button
                     class="btn btn-block btn-sm"
                     type="button"
                     aria-controls="account-list"
                     aria-expanded={accountListView.contextualAction === 'showMatches'}
-                    onclick={() =>
-                      (allCodesRevealed = accountListView.contextualAction === 'showAll')}
+                    disabled={alwaysShowAllCodesPending !== null}
+                    onclick={() => void toggleContextualAccountView()}
                   >
                     {#if accountListView.contextualAction === 'showAll'}
                       {tr('showAllCodes')}
@@ -1031,6 +1085,23 @@
                       <ChevronUp size={16} aria-hidden="true" />
                     {/if}
                   </button>
+                  <label
+                    class={[
+                      'flex min-h-10 items-center justify-center gap-2 rounded-field text-center text-sm text-base-content/70',
+                      alwaysShowAllCodesPending === null
+                        ? 'cursor-pointer'
+                        : 'cursor-wait opacity-60'
+                    ]}
+                  >
+                    <input
+                      class="checkbox checkbox-sm shrink-0"
+                      type="checkbox"
+                      checked={alwaysShowAllCodes}
+                      disabled={alwaysShowAllCodesPending !== null}
+                      onchange={(event) => void setAlwaysShowAllCodes(event.currentTarget)}
+                    />
+                    <span>{tr('alwaysShowAllCodes')}</span>
+                  </label>
                 </div>
               {/if}
             {:else if vault.accounts.length === 0}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -4,6 +4,8 @@
   import { fade } from 'svelte/transition';
   import {
     ClipboardPaste,
+    ChevronDown,
+    ChevronUp,
     Download,
     ImageUp,
     KeyRound,
@@ -34,7 +36,11 @@
     rubberbandOffset
   } from './lib/components/auth/reorder';
   import { accountToOtpAuthUri } from './lib/auth/otpauth';
-  import { getAccountPageRanking, type PageContext } from './lib/auth/accountRanking';
+  import {
+    getAccountListView,
+    getAccountPageRanking,
+    type PageContext
+  } from './lib/auth/accountRanking';
   import { decodeQrFiles, renderQrDataUrl } from './lib/auth/qr';
   import type { AccountDraft, AuthenticatorAccount, ImportResult } from './lib/auth/types';
   import { authenticatorVault as vault } from './lib/state/authenticator.svelte';
@@ -118,6 +124,7 @@
   let pageScanError = $state('');
   let pageContext = $state.raw<PageContext | null>(null);
   let pageContextReady = $state(false);
+  let allCodesRevealed = $state(false);
   let pageContextRequest = 0;
   let browserWindowId: number | undefined;
 
@@ -126,16 +133,13 @@
     getAccountPageRanking(vault.sortedAccounts, manualSort ? null : pageContext)
   );
   const orderedAccounts = $derived.by(() => dragAccounts ?? pageRanking.accounts);
-  const filteredAccounts = $derived.by(() => {
-    const needle = query.trim().toLowerCase();
-    if (!needle) {
-      return orderedAccounts;
-    }
-    return orderedAccounts.filter(
-      (account) =>
-        account.label.toLowerCase().includes(needle) || account.issuer.toLowerCase().includes(needle)
-    );
-  });
+  const accountListView = $derived(
+    getAccountListView(orderedAccounts, pageRanking.suggestedAccountIds, {
+      query,
+      revealAll: allCodesRevealed
+    })
+  );
+  const filteredAccounts = $derived(accountListView.accounts);
   const reorderDisabled = $derived(
     !manualSort || query.trim().length > 0 || filteredAccounts.length < 2
   );
@@ -265,6 +269,7 @@
     const request = ++pageContextRequest;
     if (clearCurrent) {
       pageContext = null;
+      allCodesRevealed = false;
     }
     if (vault.settings.accountSortMode === 'manual' || !hasRuntimeMessaging()) {
       pageContext = null;
@@ -277,7 +282,11 @@
         windowId: browserWindowId
       });
       if (request === pageContextRequest) {
-        pageContext = parsePageContext(response.pageContext);
+        const nextContext = parsePageContext(response.pageContext);
+        if (nextContext?.hostname !== pageContext?.hostname) {
+          allCodesRevealed = false;
+        }
+        pageContext = nextContext;
       }
     } catch {
       // Context is optional. Manual order is the quiet fallback when the
@@ -981,6 +990,7 @@
 
             {#if filteredAccounts.length > 0}
               <ul
+                id="account-list"
                 class="divide-y divide-base-200"
                 aria-label={tr('accounts')}
                 bind:this={accountListElement}
@@ -1003,6 +1013,26 @@
                   />
                 {/each}
               </ul>
+              {#if accountListView.contextualAction}
+                <div class="px-3 py-3">
+                  <button
+                    class="btn btn-block btn-sm"
+                    type="button"
+                    aria-controls="account-list"
+                    aria-expanded={accountListView.contextualAction === 'showMatches'}
+                    onclick={() =>
+                      (allCodesRevealed = accountListView.contextualAction === 'showAll')}
+                  >
+                    {#if accountListView.contextualAction === 'showAll'}
+                      {tr('showAllCodes')}
+                      <ChevronDown size={16} aria-hidden="true" />
+                    {:else}
+                      {tr('showSiteMatches')}
+                      <ChevronUp size={16} aria-hidden="true" />
+                    {/if}
+                  </button>
+                </div>
+              {/if}
             {:else if vault.accounts.length === 0}
               <div class="grid grow place-items-center p-8 text-center">
                 <div class="grid justify-items-center gap-3">

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -5,7 +5,6 @@
   import {
     ClipboardPaste,
     ChevronDown,
-    ChevronUp,
     Download,
     ImageUp,
     KeyRound,
@@ -28,6 +27,7 @@
   import {
     FADE_TRANSITION,
     PANEL_TRANSITION,
+    panelReveal,
     viewTransition
   } from './lib/components/auth/transitions';
   import {
@@ -124,8 +124,7 @@
   let pageScanError = $state('');
   let pageContext = $state.raw<PageContext | null>(null);
   let pageContextReady = $state(false);
-  let showAllCodesOverride = $state<boolean | null>(null);
-  let alwaysShowAllCodesPending = $state<boolean | null>(null);
+  let allCodesRevealed = $state(false);
   let pageContextRequest = 0;
   let browserWindowId: number | undefined;
 
@@ -134,16 +133,15 @@
     getAccountPageRanking(vault.sortedAccounts, manualSort ? null : pageContext)
   );
   const orderedAccounts = $derived.by(() => dragAccounts ?? pageRanking.accounts);
-  const alwaysShowAllCodes = $derived(
-    alwaysShowAllCodesPending ?? vault.settings.alwaysShowAllCodes
-  );
   const accountListView = $derived(
     getAccountListView(orderedAccounts, pageRanking.suggestedAccountIds, {
       query,
-      revealAll: showAllCodesOverride ?? alwaysShowAllCodes
+      alwaysShowAll: vault.settings.alwaysShowAllCodes,
+      revealAll: allCodesRevealed
     })
   );
   const filteredAccounts = $derived(accountListView.accounts);
+  const codesRevealed = $derived(accountListView.contextualAction === 'showMatches');
   const reorderDisabled = $derived(
     !manualSort || query.trim().length > 0 || filteredAccounts.length < 2
   );
@@ -269,61 +267,17 @@
     }
   }
 
-  async function setAlwaysShowAllCodes(input: HTMLInputElement) {
-    if (alwaysShowAllCodesPending !== null) {
-      input.checked = alwaysShowAllCodes;
-      return;
-    }
-
-    const enabled = input.checked;
-    const previousOverride = showAllCodesOverride;
-    showAllCodesOverride = null;
-    alwaysShowAllCodesPending = enabled;
-    try {
-      await vault.updateSettings({ alwaysShowAllCodes: enabled });
-      showAllCodesOverride = null;
-    } catch (error) {
-      showAllCodesOverride = previousOverride;
-      vault.error = getErrorMessage(error, tr('settingsSaveFailed'));
-    } finally {
-      alwaysShowAllCodesPending = null;
-      input.checked = vault.settings.alwaysShowAllCodes;
-    }
-  }
-
-  async function toggleContextualAccountView() {
-    if (alwaysShowAllCodesPending !== null) {
-      return;
-    }
-
-    if (accountListView.contextualAction === 'showAll') {
-      showAllCodesOverride = true;
-      return;
-    }
-
-    const previousOverride = showAllCodesOverride;
-    showAllCodesOverride = false;
-    if (!vault.settings.alwaysShowAllCodes) {
-      return;
-    }
-
-    alwaysShowAllCodesPending = false;
-    try {
-      await vault.updateSettings({ alwaysShowAllCodes: false });
-      showAllCodesOverride = null;
-    } catch (error) {
-      showAllCodesOverride = previousOverride;
-      vault.error = getErrorMessage(error, tr('settingsSaveFailed'));
-    } finally {
-      alwaysShowAllCodesPending = null;
-    }
+  // Revealing every code is a per-visit choice, so this never rewrites
+  // settings. Preferring the full list hides this control altogether.
+  function toggleContextualAccountView() {
+    allCodesRevealed = !allCodesRevealed;
   }
 
   async function refreshPageContext(clearCurrent = true) {
     const request = ++pageContextRequest;
     if (clearCurrent) {
       pageContext = null;
-      showAllCodesOverride = null;
+      allCodesRevealed = false;
     }
     if (vault.settings.accountSortMode === 'manual' || !hasRuntimeMessaging()) {
       pageContext = null;
@@ -338,7 +292,7 @@
       if (request === pageContextRequest) {
         const nextContext = parsePageContext(response.pageContext);
         if (nextContext?.hostname !== pageContext?.hostname) {
-          showAllCodesOverride = null;
+          allCodesRevealed = false;
         }
         pageContext = nextContext;
       }
@@ -1000,6 +954,26 @@
   <title>{tr('appName')}</title>
 </svelte:head>
 
+{#snippet accountRows(accounts: AuthenticatorAccount[])}
+  {#each accounts as account (account.id)}
+    <AccountRow
+      {account}
+      code={vault.codes[account.id]}
+      suggestedForSite={pageRanking.suggestedAccountIds.has(account.id)}
+      showReorder={manualSort}
+      reorderDisabled={reorderDisabled}
+      reorderPending={reorderSaving}
+      dragging={activeDragAccountId === account.id}
+      dragStyle={getAccountDragStyle(account)}
+      oncodecopy={copyCode}
+      onactions={(item) => (actionsFor = item)}
+      onreorderstart={startAccountDrag}
+      onreorderkey={handleAccountDragKey}
+      onreorderblur={handleAccountDragBlur}
+    />
+  {/each}
+{/snippet}
+
 <div class="contents" data-theme={themeOverride}>
 <main
   class="relative flex h-full min-h-0 w-full min-w-0 flex-col overflow-hidden bg-base-100 text-base-content"
@@ -1032,7 +1006,12 @@
         >
           <AppBar onsettings={showSettings} />
 
-          <div class="flex grow flex-col overflow-y-auto pb-20" bind:this={scrollContainerElement}>
+          <!-- The reserved gutter keeps the list from shifting sideways when
+               revealing more codes makes the scrollbar appear. -->
+          <div
+            class="auth-scroll-area flex grow flex-col overflow-y-auto pb-20"
+            bind:this={scrollContainerElement}
+          >
             {#if vault.accounts.length > 0}
               <div class="auth-sticky-search sticky top-0 z-10 bg-base-100/95 px-3 py-2 backdrop-blur">
                 <label class="auth-search-input input input-md w-full items-center gap-2">
@@ -1044,64 +1023,48 @@
 
             {#if filteredAccounts.length > 0}
               <ul
-                id="account-list"
                 class="divide-y divide-base-200"
                 aria-label={tr('accounts')}
                 bind:this={accountListElement}
               >
-                {#each filteredAccounts as account (account.id)}
-                  <AccountRow
-                    {account}
-                    code={vault.codes[account.id]}
-                    suggestedForSite={pageRanking.suggestedAccountIds.has(account.id)}
-                    showReorder={manualSort}
-                    reorderDisabled={reorderDisabled}
-                    reorderPending={reorderSaving}
-                    dragging={activeDragAccountId === account.id}
-                    dragStyle={getAccountDragStyle(account)}
-                    oncodecopy={copyCode}
-                    onactions={(item) => (actionsFor = item)}
-                    onreorderstart={startAccountDrag}
-                    onreorderkey={handleAccountDragKey}
-                    onreorderblur={handleAccountDragBlur}
-                  />
-                {/each}
+                {@render accountRows(filteredAccounts)}
               </ul>
+
               {#if accountListView.contextualAction}
-                <div class="space-y-1 px-3 pb-2 pt-3">
+                <!-- Sits between the site matches and the rest, so it stays in
+                     the same place whichever way the list is showing. -->
+                <div class="flex items-center gap-2 px-3 py-2.5">
+                  <span class="h-px grow bg-base-200/70" aria-hidden="true"></span>
                   <button
-                    class="btn btn-block btn-sm"
+                    class="btn btn-xs h-7 shrink-0 gap-1.5 rounded-full border-0 bg-base-200/70 px-3 text-xs font-medium text-base-content/70 shadow-none hover:bg-base-200 hover:text-base-content"
                     type="button"
-                    aria-controls="account-list"
-                    aria-expanded={accountListView.contextualAction === 'showMatches'}
-                    disabled={alwaysShowAllCodesPending !== null}
-                    onclick={() => void toggleContextualAccountView()}
+                    aria-controls="other-codes"
+                    aria-expanded={codesRevealed}
+                    onclick={toggleContextualAccountView}
                   >
-                    {#if accountListView.contextualAction === 'showAll'}
-                      {tr('showAllCodes')}
-                      <ChevronDown size={16} aria-hidden="true" />
-                    {:else}
-                      {tr('showSiteMatches')}
-                      <ChevronUp size={16} aria-hidden="true" />
+                    {codesRevealed ? tr('showSiteMatches') : tr('showAllCodes')}
+                    {#if !codesRevealed}
+                      <span class="tabular-nums opacity-55">{accountListView.hiddenCount}</span>
                     {/if}
-                  </button>
-                  <label
-                    class={[
-                      'flex min-h-10 items-center justify-center gap-2 rounded-field text-center text-sm text-base-content/70',
-                      alwaysShowAllCodesPending === null
-                        ? 'cursor-pointer'
-                        : 'cursor-wait opacity-60'
-                    ]}
-                  >
-                    <input
-                      class="checkbox checkbox-sm shrink-0"
-                      type="checkbox"
-                      checked={alwaysShowAllCodes}
-                      disabled={alwaysShowAllCodesPending !== null}
-                      onchange={(event) => void setAlwaysShowAllCodes(event.currentTarget)}
+                    <ChevronDown
+                      class={['transition-transform duration-200', codesRevealed && 'rotate-180']}
+                      size={14}
+                      aria-hidden="true"
                     />
-                    <span>{tr('alwaysShowAllCodes')}</span>
-                  </label>
+                  </button>
+                  <span class="h-px grow bg-base-200/70" aria-hidden="true"></span>
+                </div>
+
+                <div id="other-codes">
+                  {#if codesRevealed}
+                    <ul
+                      class="divide-y divide-base-200"
+                      aria-label={tr('otherCodes')}
+                      transition:panelReveal
+                    >
+                      {@render accountRows(accountListView.revealedAccounts)}
+                    </ul>
+                  {/if}
                 </div>
               {/if}
             {:else if vault.accounts.length === 0}

--- a/src/app.css
+++ b/src/app.css
@@ -188,6 +188,10 @@ select:not(:disabled),
   background-color: color-mix(in oklab, var(--color-base-200) 45%, var(--color-base-100));
 }
 
+.auth-scroll-area {
+  scrollbar-gutter: stable;
+}
+
 .auth-search-input.input {
   border-color: transparent;
   background-color: color-mix(in oklab, var(--color-base-200) 55%, var(--color-base-100));

--- a/src/lib/auth/accountRanking.ts
+++ b/src/lib/auth/accountRanking.ts
@@ -35,7 +35,12 @@ export interface AccountPageRanking {
 }
 
 export interface AccountListView {
+  /** Accounts rendered above the reveal control. */
   accounts: AuthenticatorAccount[];
+  /** Accounts rendered below the reveal control once every code is revealed. */
+  revealedAccounts: AuthenticatorAccount[];
+  /** How many accounts the reveal control adds to the list. */
+  hiddenCount: number;
   contextualAction: 'showAll' | 'showMatches' | null;
 }
 
@@ -146,30 +151,43 @@ export function getAccountPageRanking(
 export function getAccountListView(
   accounts: readonly AuthenticatorAccount[],
   suggestedAccountIds: ReadonlySet<string>,
-  options: { query: string; revealAll: boolean }
+  options: { query: string; alwaysShowAll: boolean; revealAll: boolean }
 ): AccountListView {
   const needle = options.query.trim().toLowerCase();
   if (needle) {
-    return {
-      accounts: accounts.filter(
+    return flatListView(
+      accounts.filter(
         (account) =>
           account.label.toLowerCase().includes(needle) ||
           account.issuer.toLowerCase().includes(needle)
-      ),
-      contextualAction: null
-    };
+      )
+    );
+  }
+
+  // Preferring the full list drops the grouping altogether, so there is
+  // nothing left to reveal or collapse.
+  if (options.alwaysShowAll) {
+    return flatListView([...accounts]);
   }
 
   if (suggestedAccountIds.size > 0) {
     const suggestedAccounts = accounts.filter((account) => suggestedAccountIds.has(account.id));
-    if (suggestedAccounts.length > 0 && suggestedAccounts.length < accounts.length) {
-      return options.revealAll
-        ? { accounts: [...accounts], contextualAction: 'showMatches' }
-        : { accounts: suggestedAccounts, contextualAction: 'showAll' };
+    const otherAccounts = accounts.filter((account) => !suggestedAccountIds.has(account.id));
+    if (suggestedAccounts.length > 0 && otherAccounts.length > 0) {
+      return {
+        accounts: suggestedAccounts,
+        revealedAccounts: options.revealAll ? otherAccounts : [],
+        hiddenCount: otherAccounts.length,
+        contextualAction: options.revealAll ? 'showMatches' : 'showAll'
+      };
     }
   }
 
-  return { accounts: [...accounts], contextualAction: null };
+  return flatListView([...accounts]);
+}
+
+function flatListView(accounts: AuthenticatorAccount[]): AccountListView {
+  return { accounts, revealedAccounts: [], hiddenCount: 0, contextualAction: null };
 }
 
 export function getAccountPageMatchScore(

--- a/src/lib/auth/accountRanking.ts
+++ b/src/lib/auth/accountRanking.ts
@@ -34,6 +34,11 @@ export interface AccountPageRanking {
   suggestedAccountIds: ReadonlySet<string>;
 }
 
+export interface AccountListView {
+  accounts: AuthenticatorAccount[];
+  contextualAction: 'showAll' | 'showMatches' | null;
+}
+
 const NAME_NOISE = new Set([
   '2fa',
   'account',
@@ -136,6 +141,35 @@ export function getAccountPageRanking(
       scoredAccounts.filter(({ score }) => score > 0).map(({ account }) => account.id)
     )
   };
+}
+
+export function getAccountListView(
+  accounts: readonly AuthenticatorAccount[],
+  suggestedAccountIds: ReadonlySet<string>,
+  options: { query: string; revealAll: boolean }
+): AccountListView {
+  const needle = options.query.trim().toLowerCase();
+  if (needle) {
+    return {
+      accounts: accounts.filter(
+        (account) =>
+          account.label.toLowerCase().includes(needle) ||
+          account.issuer.toLowerCase().includes(needle)
+      ),
+      contextualAction: null
+    };
+  }
+
+  if (suggestedAccountIds.size > 0) {
+    const suggestedAccounts = accounts.filter((account) => suggestedAccountIds.has(account.id));
+    if (suggestedAccounts.length > 0 && suggestedAccounts.length < accounts.length) {
+      return options.revealAll
+        ? { accounts: [...accounts], contextualAction: 'showMatches' }
+        : { accounts: suggestedAccounts, contextualAction: 'showAll' };
+    }
+  }
+
+  return { accounts: [...accounts], contextualAction: null };
 }
 
 export function getAccountPageMatchScore(

--- a/src/lib/auth/types.ts
+++ b/src/lib/auth/types.ts
@@ -59,6 +59,7 @@ export interface AppSettings {
   hideCodes: boolean;
   autoPasteCodes: boolean;
   accountSortMode: AccountSortMode;
+  alwaysShowAllCodes: boolean;
 }
 
 export interface VaultEnvelope {
@@ -94,7 +95,8 @@ export const DEFAULT_SETTINGS: AppSettings = {
   showCountdownSeconds: false,
   hideCodes: false,
   autoPasteCodes: false,
-  accountSortMode: 'contextual'
+  accountSortMode: 'contextual',
+  alwaysShowAllCodes: false
 };
 
 export function normalizeAppSettings(settings: Partial<AppSettings> | undefined): AppSettings {
@@ -102,7 +104,8 @@ export function normalizeAppSettings(settings: Partial<AppSettings> | undefined)
     ...DEFAULT_SETTINGS,
     ...settings,
     hideCodes: settings?.hideCodes === true,
-    accountSortMode: settings?.accountSortMode === 'manual' ? 'manual' : 'contextual'
+    accountSortMode: settings?.accountSortMode === 'manual' ? 'manual' : 'contextual',
+    alwaysShowAllCodes: settings?.alwaysShowAllCodes === true
   };
 }
 

--- a/src/lib/components/auth/SettingsView.svelte
+++ b/src/lib/components/auth/SettingsView.svelte
@@ -275,6 +275,23 @@
         />
       </label>
 
+      {#if vault.settings.accountSortMode === 'contextual'}
+        <div transition:panelReveal>
+          <label class="flex items-center justify-between gap-3 border-s-2 border-base-200 ps-3">
+            <span class="min-w-0">
+              <span class="block text-sm font-medium">{tr('alwaysShowAllCodes')}</span>
+              <span class="block text-xs text-base-content/60">{tr('alwaysShowAllCodesHint')}</span>
+            </span>
+            <input
+              class="toggle toggle-primary toggle-sm shrink-0"
+              type="checkbox"
+              checked={vault.settings.alwaysShowAllCodes}
+              onchange={(event) => saveSettings({ alwaysShowAllCodes: event.currentTarget.checked })}
+            />
+          </label>
+        </div>
+      {/if}
+
       <label class="flex items-center justify-between gap-3">
         <span class="min-w-0">
           <span class="flex flex-wrap items-center gap-1.5 text-sm font-medium">

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -90,7 +90,9 @@ export const MESSAGE_KEYS = [
   'siteSuggestion',
   'showAllCodes',
   'showSiteMatches',
+  'otherCodes',
   'alwaysShowAllCodes',
+  'alwaysShowAllCodesHint',
   'settingsSaveFailed',
   'autoPasteCodes',
   'autoPasteCodesHint',
@@ -209,11 +211,13 @@ const en: Record<MessageKey, string> = {
     'Mask codes in the account list. Select an account to copy its code; auto-paste still works.',
   autoSortCodes: 'Filter codes by site',
   autoSortCodesHint:
-    'Show likely matches for the current site. Search or reveal all codes anytime; turn this off to reorder codes.',
+    'Show only likely matches for the current site. Turn this off to arrange codes yourself.',
   siteSuggestion: 'Suggested for this site',
   showAllCodes: 'Show all codes',
-  showSiteMatches: 'Show site matches only',
+  showSiteMatches: 'Site matches only',
+  otherCodes: 'Other codes',
   alwaysShowAllCodes: 'Always show all codes',
+  alwaysShowAllCodesHint: 'Open the full list instead of only the current site’s matches.',
   settingsSaveFailed: 'Unable to save settings.',
   autoPasteCodes: 'Auto paste code',
   autoPasteCodesHint:
@@ -319,11 +323,14 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
       'Oculta los códigos en la lista de cuentas. Selecciona una cuenta para copiar su código; el pegado automático sigue funcionando.',
     autoSortCodes: 'Filtrar códigos por sitio',
     autoSortCodesHint:
-      'Muestra coincidencias probables para el sitio actual. Puedes buscar o mostrar todos los códigos; desactiva esta opción para reordenarlos.',
+      'Muestra solo las coincidencias probables para el sitio actual. Desactiva esta opción para ordenar los códigos manualmente.',
     siteSuggestion: 'Sugerido para este sitio',
     showAllCodes: 'Mostrar todos los códigos',
-    showSiteMatches: 'Mostrar solo coincidencias del sitio',
+    showSiteMatches: 'Solo coincidencias del sitio',
+    otherCodes: 'Otros códigos',
     alwaysShowAllCodes: 'Mostrar siempre todos los códigos',
+    alwaysShowAllCodesHint:
+      'Abre la lista completa en lugar de solo las coincidencias del sitio actual.',
     settingsSaveFailed: 'No se pudo guardar la configuración.',
     autoPasteCodes: 'Pegar código automáticamente',
     autoPasteCodesHint:
@@ -426,11 +433,13 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
       'खाता सूची में कोड छिपाएं। कोड कॉपी करने के लिए खाता चुनें; ऑटो-पेस्ट फिर भी काम करता है।',
     autoSortCodes: 'साइट के अनुसार कोड फ़िल्टर करें',
     autoSortCodesHint:
-      'मौजूदा साइट से संभावित रूप से मेल खाने वाले कोड दिखाएं। सभी कोड खोजे या दिखाए जा सकते हैं; उन्हें क्रमबद्ध करने के लिए इसे बंद करें।',
+      'सिर्फ़ मौजूदा साइट से संभावित रूप से मेल खाने वाले कोड दिखाएं। कोड खुद क्रमबद्ध करने के लिए इसे बंद करें।',
     siteSuggestion: 'इस साइट के लिए सुझाया गया',
     showAllCodes: 'सभी कोड दिखाएं',
-    showSiteMatches: 'सिर्फ़ साइट से मेल खाने वाले कोड दिखाएं',
+    showSiteMatches: 'सिर्फ़ साइट के मेल',
+    otherCodes: 'अन्य कोड',
     alwaysShowAllCodes: 'हमेशा सभी कोड दिखाएं',
+    alwaysShowAllCodesHint: 'सिर्फ़ मौजूदा साइट के मेल के बजाय पूरी सूची खोलें।',
     settingsSaveFailed: 'सेटिंग सहेजी नहीं जा सकीं।',
     autoPasteCodes: 'कोड अपने आप पेस्ट करें',
     autoPasteCodesHint:
@@ -533,11 +542,13 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
       'أخفِ الرموز في قائمة الحسابات. حدد حسابًا لنسخ رمزه؛ ويستمر اللصق التلقائي في العمل.',
     autoSortCodes: 'تصفية الرموز حسب الموقع',
     autoSortCodesHint:
-      'اعرض الرموز التي يُرجح أن تطابق الموقع الحالي. يمكنك البحث في كل الرموز أو عرضها؛ أوقف هذا الخيار لإعادة ترتيبها.',
+      'اعرض الرموز التي يُرجح أن تطابق الموقع الحالي فقط. أوقف هذا الخيار لترتيب الرموز بنفسك.',
     siteSuggestion: 'مقترح لهذا الموقع',
     showAllCodes: 'عرض كل الرموز',
-    showSiteMatches: 'عرض رموز الموقع المطابقة فقط',
+    showSiteMatches: 'مطابقات الموقع فقط',
+    otherCodes: 'رموز أخرى',
     alwaysShowAllCodes: 'عرض كل الرموز دائمًا',
+    alwaysShowAllCodesHint: 'افتح القائمة الكاملة بدلًا من مطابقات الموقع الحالي فقط.',
     settingsSaveFailed: 'تعذّر حفظ الإعدادات.',
     autoPasteCodes: 'لصق الرمز تلقائيا',
     autoPasteCodesHint:
@@ -640,11 +651,13 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
       'অ্যাকাউন্ট তালিকায় কোড লুকিয়ে রাখুন। কোড কপি করতে একটি অ্যাকাউন্ট নির্বাচন করুন; অটো-পেস্ট তবুও কাজ করে।',
     autoSortCodes: 'সাইট অনুযায়ী কোড ফিল্টার করুন',
     autoSortCodesHint:
-      'বর্তমান সাইটের সঙ্গে সম্ভাব্য মিল থাকা কোড দেখান। সব কোড খোঁজা বা দেখানো যাবে; সেগুলো সাজাতে এটি বন্ধ করুন।',
+      'শুধু বর্তমান সাইটের সঙ্গে সম্ভাব্য মিল থাকা কোড দেখান। নিজে কোড সাজাতে এটি বন্ধ করুন।',
     siteSuggestion: 'এই সাইটের জন্য প্রস্তাবিত',
     showAllCodes: 'সব কোড দেখান',
-    showSiteMatches: 'শুধু সাইটের সঙ্গে মিল থাকা কোড দেখান',
+    showSiteMatches: 'শুধু সাইটের মিল',
+    otherCodes: 'অন্যান্য কোড',
     alwaysShowAllCodes: 'সব সময় সব কোড দেখান',
+    alwaysShowAllCodesHint: 'শুধু বর্তমান সাইটের মিলের বদলে পুরো তালিকা খুলুন।',
     settingsSaveFailed: 'সেটিংস সংরক্ষণ করা যায়নি।',
     autoPasteCodes: 'কোড অটো পেস্ট করুন',
     autoPasteCodesHint:
@@ -747,11 +760,14 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
       'Oculte os códigos na lista de contas. Selecione uma conta para copiar o código; a colagem automática continua funcionando.',
     autoSortCodes: 'Filtrar códigos por site',
     autoSortCodesHint:
-      'Mostra correspondências prováveis para o site atual. Pode pesquisar ou mostrar todos os códigos; desative para os reordenar.',
+      'Mostra apenas as correspondências prováveis para o site atual. Desative para organizar os códigos manualmente.',
     siteSuggestion: 'Sugerido para este site',
     showAllCodes: 'Mostrar todos os códigos',
-    showSiteMatches: 'Mostrar apenas correspondências do site',
+    showSiteMatches: 'Apenas o site atual',
+    otherCodes: 'Outros códigos',
     alwaysShowAllCodes: 'Mostrar sempre todos os códigos',
+    alwaysShowAllCodesHint:
+      'Abre a lista completa em vez de apenas as correspondências do site atual.',
     settingsSaveFailed: 'Não foi possível salvar as configurações.',
     autoPasteCodes: 'Colar código automaticamente',
     autoPasteCodesHint:
@@ -854,11 +870,14 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
       'Скрывает коды в списке аккаунтов. Выберите аккаунт, чтобы скопировать код; автовставка продолжит работать.',
     autoSortCodes: 'Фильтровать коды по сайту',
     autoSortCodesHint:
-      'Показывает вероятные совпадения для текущего сайта. Все коды можно найти через поиск или показать; отключите, чтобы менять их порядок.',
+      'Показывать только вероятные совпадения для текущего сайта. Отключите, чтобы упорядочить коды вручную.',
     siteSuggestion: 'Предложено для этого сайта',
     showAllCodes: 'Показать все коды',
-    showSiteMatches: 'Показать только совпадения для сайта',
+    showSiteMatches: 'Только совпадения сайта',
+    otherCodes: 'Другие коды',
     alwaysShowAllCodes: 'Всегда показывать все коды',
+    alwaysShowAllCodesHint:
+      'Открывать полный список вместо совпадений только для текущего сайта.',
     settingsSaveFailed: 'Не удалось сохранить настройки.',
     autoPasteCodes: 'Автовставка кода',
     autoPasteCodesHint:
@@ -961,11 +980,13 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
       'アカウント一覧のコードを隠します。アカウントを選択するとコードをコピーでき、自動貼り付けも引き続き機能します。',
     autoSortCodes: 'サイト別にコードを絞り込む',
     autoSortCodesHint:
-      '現在のサイトに一致する可能性が高いコードを表示します。すべてのコードの検索や表示もできます。並べ替えるにはオフにします。',
+      '現在のサイトに一致する可能性が高いコードだけを表示します。自分で並べ替えるにはオフにします。',
     siteSuggestion: 'このサイトの候補',
     showAllCodes: 'すべてのコードを表示',
-    showSiteMatches: 'サイトに一致するコードのみ表示',
+    showSiteMatches: 'サイトの候補のみ',
+    otherCodes: 'その他のコード',
     alwaysShowAllCodes: '常にすべてのコードを表示',
+    alwaysShowAllCodesHint: '現在のサイトの候補だけでなく、最初から一覧全体を表示します。',
     settingsSaveFailed: '設定を保存できませんでした。',
     autoPasteCodes: 'コードを自動貼り付け',
     autoPasteCodesHint:
@@ -1068,11 +1089,14 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
       'Masque les codes dans la liste des comptes. Sélectionnez un compte pour copier son code ; le collage automatique continue de fonctionner.',
     autoSortCodes: 'Filtrer les codes par site',
     autoSortCodesHint:
-      'Affiche les correspondances probables pour le site actuel. Vous pouvez rechercher ou afficher tous les codes ; désactivez cette option pour les réorganiser.',
+      'Affiche uniquement les correspondances probables pour le site actuel. Désactivez cette option pour organiser les codes vous-même.',
     siteSuggestion: 'Suggéré pour ce site',
     showAllCodes: 'Afficher tous les codes',
-    showSiteMatches: 'Afficher uniquement les correspondances du site',
+    showSiteMatches: 'Site actuel uniquement',
+    otherCodes: 'Autres codes',
     alwaysShowAllCodes: 'Toujours afficher tous les codes',
+    alwaysShowAllCodesHint:
+      'Ouvre la liste complète au lieu des seules correspondances du site actuel.',
     settingsSaveFailed: 'Impossible d’enregistrer les paramètres.',
     autoPasteCodes: 'Coller le code automatiquement',
     autoPasteCodesHint:
@@ -1175,11 +1199,14 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
       'Blendet Codes in der Kontoliste aus. Wähle ein Konto aus, um den Code zu kopieren; automatisches Einfügen funktioniert weiterhin.',
     autoSortCodes: 'Codes nach Website filtern',
     autoSortCodesHint:
-      'Zeigt wahrscheinliche Treffer für die aktuelle Website. Du kannst alle Codes durchsuchen oder anzeigen; schalte dies zum Sortieren aus.',
+      'Zeigt nur wahrscheinliche Treffer für die aktuelle Website. Schalte dies aus, um die Codes selbst anzuordnen.',
     siteSuggestion: 'Für diese Website vorgeschlagen',
     showAllCodes: 'Alle Codes anzeigen',
-    showSiteMatches: 'Nur Website-Treffer anzeigen',
+    showSiteMatches: 'Nur Website-Treffer',
+    otherCodes: 'Weitere Codes',
     alwaysShowAllCodes: 'Immer alle Codes anzeigen',
+    alwaysShowAllCodesHint:
+      'Öffnet die vollständige Liste statt nur der Treffer für die aktuelle Website.',
     settingsSaveFailed: 'Einstellungen konnten nicht gespeichert werden.',
     autoPasteCodes: 'Code automatisch einfügen',
     autoPasteCodesHint:
@@ -1280,11 +1307,13 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
     hideCodes: '隐藏验证码',
     hideCodesHint: '在账户列表中隐藏验证码。选择账户即可复制验证码；自动粘贴仍然有效。',
     autoSortCodes: '按网站筛选验证码',
-    autoSortCodesHint: '显示可能与当前网站匹配的验证码。仍可搜索或显示所有验证码；关闭后可手动排序。',
+    autoSortCodesHint: '仅显示可能与当前网站匹配的验证码。关闭后可手动排列验证码。',
     siteSuggestion: '为此网站推荐',
     showAllCodes: '显示所有验证码',
-    showSiteMatches: '仅显示网站匹配项',
+    showSiteMatches: '仅当前网站',
+    otherCodes: '其他验证码',
     alwaysShowAllCodes: '始终显示所有验证码',
+    alwaysShowAllCodesHint: '打开时显示完整列表，而不仅是当前网站的匹配项。',
     settingsSaveFailed: '无法保存设置。',
     autoPasteCodes: '自动粘贴代码',
     autoPasteCodesHint:

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -90,6 +90,7 @@ export const MESSAGE_KEYS = [
   'siteSuggestion',
   'showAllCodes',
   'showSiteMatches',
+  'alwaysShowAllCodes',
   'settingsSaveFailed',
   'autoPasteCodes',
   'autoPasteCodesHint',
@@ -212,6 +213,7 @@ const en: Record<MessageKey, string> = {
   siteSuggestion: 'Suggested for this site',
   showAllCodes: 'Show all codes',
   showSiteMatches: 'Show site matches only',
+  alwaysShowAllCodes: 'Always show all codes',
   settingsSaveFailed: 'Unable to save settings.',
   autoPasteCodes: 'Auto paste code',
   autoPasteCodesHint:
@@ -321,6 +323,7 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
     siteSuggestion: 'Sugerido para este sitio',
     showAllCodes: 'Mostrar todos los códigos',
     showSiteMatches: 'Mostrar solo coincidencias del sitio',
+    alwaysShowAllCodes: 'Mostrar siempre todos los códigos',
     settingsSaveFailed: 'No se pudo guardar la configuración.',
     autoPasteCodes: 'Pegar código automáticamente',
     autoPasteCodesHint:
@@ -427,6 +430,7 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
     siteSuggestion: 'इस साइट के लिए सुझाया गया',
     showAllCodes: 'सभी कोड दिखाएं',
     showSiteMatches: 'सिर्फ़ साइट से मेल खाने वाले कोड दिखाएं',
+    alwaysShowAllCodes: 'हमेशा सभी कोड दिखाएं',
     settingsSaveFailed: 'सेटिंग सहेजी नहीं जा सकीं।',
     autoPasteCodes: 'कोड अपने आप पेस्ट करें',
     autoPasteCodesHint:
@@ -533,6 +537,7 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
     siteSuggestion: 'مقترح لهذا الموقع',
     showAllCodes: 'عرض كل الرموز',
     showSiteMatches: 'عرض رموز الموقع المطابقة فقط',
+    alwaysShowAllCodes: 'عرض كل الرموز دائمًا',
     settingsSaveFailed: 'تعذّر حفظ الإعدادات.',
     autoPasteCodes: 'لصق الرمز تلقائيا',
     autoPasteCodesHint:
@@ -639,6 +644,7 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
     siteSuggestion: 'এই সাইটের জন্য প্রস্তাবিত',
     showAllCodes: 'সব কোড দেখান',
     showSiteMatches: 'শুধু সাইটের সঙ্গে মিল থাকা কোড দেখান',
+    alwaysShowAllCodes: 'সব সময় সব কোড দেখান',
     settingsSaveFailed: 'সেটিংস সংরক্ষণ করা যায়নি।',
     autoPasteCodes: 'কোড অটো পেস্ট করুন',
     autoPasteCodesHint:
@@ -745,6 +751,7 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
     siteSuggestion: 'Sugerido para este site',
     showAllCodes: 'Mostrar todos os códigos',
     showSiteMatches: 'Mostrar apenas correspondências do site',
+    alwaysShowAllCodes: 'Mostrar sempre todos os códigos',
     settingsSaveFailed: 'Não foi possível salvar as configurações.',
     autoPasteCodes: 'Colar código automaticamente',
     autoPasteCodesHint:
@@ -851,6 +858,7 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
     siteSuggestion: 'Предложено для этого сайта',
     showAllCodes: 'Показать все коды',
     showSiteMatches: 'Показать только совпадения для сайта',
+    alwaysShowAllCodes: 'Всегда показывать все коды',
     settingsSaveFailed: 'Не удалось сохранить настройки.',
     autoPasteCodes: 'Автовставка кода',
     autoPasteCodesHint:
@@ -957,6 +965,7 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
     siteSuggestion: 'このサイトの候補',
     showAllCodes: 'すべてのコードを表示',
     showSiteMatches: 'サイトに一致するコードのみ表示',
+    alwaysShowAllCodes: '常にすべてのコードを表示',
     settingsSaveFailed: '設定を保存できませんでした。',
     autoPasteCodes: 'コードを自動貼り付け',
     autoPasteCodesHint:
@@ -1063,6 +1072,7 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
     siteSuggestion: 'Suggéré pour ce site',
     showAllCodes: 'Afficher tous les codes',
     showSiteMatches: 'Afficher uniquement les correspondances du site',
+    alwaysShowAllCodes: 'Toujours afficher tous les codes',
     settingsSaveFailed: 'Impossible d’enregistrer les paramètres.',
     autoPasteCodes: 'Coller le code automatiquement',
     autoPasteCodesHint:
@@ -1169,6 +1179,7 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
     siteSuggestion: 'Für diese Website vorgeschlagen',
     showAllCodes: 'Alle Codes anzeigen',
     showSiteMatches: 'Nur Website-Treffer anzeigen',
+    alwaysShowAllCodes: 'Immer alle Codes anzeigen',
     settingsSaveFailed: 'Einstellungen konnten nicht gespeichert werden.',
     autoPasteCodes: 'Code automatisch einfügen',
     autoPasteCodesHint:
@@ -1273,6 +1284,7 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
     siteSuggestion: '为此网站推荐',
     showAllCodes: '显示所有验证码',
     showSiteMatches: '仅显示网站匹配项',
+    alwaysShowAllCodes: '始终显示所有验证码',
     settingsSaveFailed: '无法保存设置。',
     autoPasteCodes: '自动粘贴代码',
     autoPasteCodesHint:

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -88,6 +88,8 @@ export const MESSAGE_KEYS = [
   'autoSortCodes',
   'autoSortCodesHint',
   'siteSuggestion',
+  'showAllCodes',
+  'showSiteMatches',
   'settingsSaveFailed',
   'autoPasteCodes',
   'autoPasteCodesHint',
@@ -204,10 +206,12 @@ const en: Record<MessageKey, string> = {
   hideCodes: 'Hide codes',
   hideCodesHint:
     'Mask codes in the account list. Select an account to copy its code; auto-paste still works.',
-  autoSortCodes: 'Auto-sort codes',
+  autoSortCodes: 'Filter codes by site',
   autoSortCodesHint:
-    'Show likely matches for the current site first when available. Turn this off to arrange codes yourself.',
+    'Show likely matches for the current site. Search or reveal all codes anytime; turn this off to reorder codes.',
   siteSuggestion: 'Suggested for this site',
+  showAllCodes: 'Show all codes',
+  showSiteMatches: 'Show site matches only',
   settingsSaveFailed: 'Unable to save settings.',
   autoPasteCodes: 'Auto paste code',
   autoPasteCodesHint:
@@ -311,10 +315,12 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
     hideCodes: 'Ocultar códigos',
     hideCodesHint:
       'Oculta los códigos en la lista de cuentas. Selecciona una cuenta para copiar su código; el pegado automático sigue funcionando.',
-    autoSortCodes: 'Ordenar códigos automáticamente',
+    autoSortCodes: 'Filtrar códigos por sitio',
     autoSortCodesHint:
-      'Cuando estén disponibles, muestra primero las coincidencias probables para el sitio actual. Desactiva esta opción para ordenar los códigos manualmente.',
+      'Muestra coincidencias probables para el sitio actual. Puedes buscar o mostrar todos los códigos; desactiva esta opción para reordenarlos.',
     siteSuggestion: 'Sugerido para este sitio',
+    showAllCodes: 'Mostrar todos los códigos',
+    showSiteMatches: 'Mostrar solo coincidencias del sitio',
     settingsSaveFailed: 'No se pudo guardar la configuración.',
     autoPasteCodes: 'Pegar código automáticamente',
     autoPasteCodesHint:
@@ -415,10 +421,12 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
     hideCodes: 'कोड छिपाएं',
     hideCodesHint:
       'खाता सूची में कोड छिपाएं। कोड कॉपी करने के लिए खाता चुनें; ऑटो-पेस्ट फिर भी काम करता है।',
-    autoSortCodes: 'कोड अपने आप क्रमबद्ध करें',
+    autoSortCodes: 'साइट के अनुसार कोड फ़िल्टर करें',
     autoSortCodesHint:
-      'उपलब्ध होने पर मौजूदा साइट से संभावित रूप से मेल खाने वाले कोड पहले दिखाएं। कोड खुद क्रमबद्ध करने के लिए इसे बंद करें।',
+      'मौजूदा साइट से संभावित रूप से मेल खाने वाले कोड दिखाएं। सभी कोड खोजे या दिखाए जा सकते हैं; उन्हें क्रमबद्ध करने के लिए इसे बंद करें।',
     siteSuggestion: 'इस साइट के लिए सुझाया गया',
+    showAllCodes: 'सभी कोड दिखाएं',
+    showSiteMatches: 'सिर्फ़ साइट से मेल खाने वाले कोड दिखाएं',
     settingsSaveFailed: 'सेटिंग सहेजी नहीं जा सकीं।',
     autoPasteCodes: 'कोड अपने आप पेस्ट करें',
     autoPasteCodesHint:
@@ -519,10 +527,12 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
     hideCodes: 'إخفاء الرموز',
     hideCodesHint:
       'أخفِ الرموز في قائمة الحسابات. حدد حسابًا لنسخ رمزه؛ ويستمر اللصق التلقائي في العمل.',
-    autoSortCodes: 'ترتيب الرموز تلقائيًا',
+    autoSortCodes: 'تصفية الرموز حسب الموقع',
     autoSortCodesHint:
-      'عند توفرها، اعرض أولًا الرموز التي يُرجح أن تطابق الموقع الحالي. أوقف هذا الخيار لترتيب الرموز بنفسك.',
+      'اعرض الرموز التي يُرجح أن تطابق الموقع الحالي. يمكنك البحث في كل الرموز أو عرضها؛ أوقف هذا الخيار لإعادة ترتيبها.',
     siteSuggestion: 'مقترح لهذا الموقع',
+    showAllCodes: 'عرض كل الرموز',
+    showSiteMatches: 'عرض رموز الموقع المطابقة فقط',
     settingsSaveFailed: 'تعذّر حفظ الإعدادات.',
     autoPasteCodes: 'لصق الرمز تلقائيا',
     autoPasteCodesHint:
@@ -623,10 +633,12 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
     hideCodes: 'কোড লুকান',
     hideCodesHint:
       'অ্যাকাউন্ট তালিকায় কোড লুকিয়ে রাখুন। কোড কপি করতে একটি অ্যাকাউন্ট নির্বাচন করুন; অটো-পেস্ট তবুও কাজ করে।',
-    autoSortCodes: 'কোড স্বয়ংক্রিয়ভাবে সাজান',
+    autoSortCodes: 'সাইট অনুযায়ী কোড ফিল্টার করুন',
     autoSortCodesHint:
-      'উপলভ্য হলে বর্তমান সাইটের সঙ্গে সম্ভাব্য মিল থাকা কোড আগে দেখান। নিজে কোড সাজাতে এটি বন্ধ করুন।',
+      'বর্তমান সাইটের সঙ্গে সম্ভাব্য মিল থাকা কোড দেখান। সব কোড খোঁজা বা দেখানো যাবে; সেগুলো সাজাতে এটি বন্ধ করুন।',
     siteSuggestion: 'এই সাইটের জন্য প্রস্তাবিত',
+    showAllCodes: 'সব কোড দেখান',
+    showSiteMatches: 'শুধু সাইটের সঙ্গে মিল থাকা কোড দেখান',
     settingsSaveFailed: 'সেটিংস সংরক্ষণ করা যায়নি।',
     autoPasteCodes: 'কোড অটো পেস্ট করুন',
     autoPasteCodesHint:
@@ -727,10 +739,12 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
     hideCodes: 'Ocultar códigos',
     hideCodesHint:
       'Oculte os códigos na lista de contas. Selecione uma conta para copiar o código; a colagem automática continua funcionando.',
-    autoSortCodes: 'Ordenar códigos automaticamente',
+    autoSortCodes: 'Filtrar códigos por site',
     autoSortCodesHint:
-      'Quando disponíveis, mostra primeiro as correspondências prováveis para o site atual. Desative para organizar os códigos manualmente.',
+      'Mostra correspondências prováveis para o site atual. Pode pesquisar ou mostrar todos os códigos; desative para os reordenar.',
     siteSuggestion: 'Sugerido para este site',
+    showAllCodes: 'Mostrar todos os códigos',
+    showSiteMatches: 'Mostrar apenas correspondências do site',
     settingsSaveFailed: 'Não foi possível salvar as configurações.',
     autoPasteCodes: 'Colar código automaticamente',
     autoPasteCodesHint:
@@ -831,10 +845,12 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
     hideCodes: 'Скрывать коды',
     hideCodesHint:
       'Скрывает коды в списке аккаунтов. Выберите аккаунт, чтобы скопировать код; автовставка продолжит работать.',
-    autoSortCodes: 'Сортировать коды автоматически',
+    autoSortCodes: 'Фильтровать коды по сайту',
     autoSortCodesHint:
-      'Когда возможно, сначала показывать вероятные совпадения для текущего сайта. Отключите, чтобы упорядочить коды вручную.',
+      'Показывает вероятные совпадения для текущего сайта. Все коды можно найти через поиск или показать; отключите, чтобы менять их порядок.',
     siteSuggestion: 'Предложено для этого сайта',
+    showAllCodes: 'Показать все коды',
+    showSiteMatches: 'Показать только совпадения для сайта',
     settingsSaveFailed: 'Не удалось сохранить настройки.',
     autoPasteCodes: 'Автовставка кода',
     autoPasteCodesHint:
@@ -935,10 +951,12 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
     hideCodes: 'コードを非表示',
     hideCodesHint:
       'アカウント一覧のコードを隠します。アカウントを選択するとコードをコピーでき、自動貼り付けも引き続き機能します。',
-    autoSortCodes: 'コードを自動で並べ替え',
+    autoSortCodes: 'サイト別にコードを絞り込む',
     autoSortCodesHint:
-      '利用できる場合、現在のサイトに一致する可能性が高いコードを先に表示します。自分で並べ替えるにはオフにします。',
+      '現在のサイトに一致する可能性が高いコードを表示します。すべてのコードの検索や表示もできます。並べ替えるにはオフにします。',
     siteSuggestion: 'このサイトの候補',
+    showAllCodes: 'すべてのコードを表示',
+    showSiteMatches: 'サイトに一致するコードのみ表示',
     settingsSaveFailed: '設定を保存できませんでした。',
     autoPasteCodes: 'コードを自動貼り付け',
     autoPasteCodesHint:
@@ -1039,10 +1057,12 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
     hideCodes: 'Masquer les codes',
     hideCodesHint:
       'Masque les codes dans la liste des comptes. Sélectionnez un compte pour copier son code ; le collage automatique continue de fonctionner.',
-    autoSortCodes: 'Trier les codes automatiquement',
+    autoSortCodes: 'Filtrer les codes par site',
     autoSortCodesHint:
-      'Lorsque c’est possible, affiche d’abord les correspondances probables pour le site actuel. Désactivez cette option pour organiser les codes vous-même.',
+      'Affiche les correspondances probables pour le site actuel. Vous pouvez rechercher ou afficher tous les codes ; désactivez cette option pour les réorganiser.',
     siteSuggestion: 'Suggéré pour ce site',
+    showAllCodes: 'Afficher tous les codes',
+    showSiteMatches: 'Afficher uniquement les correspondances du site',
     settingsSaveFailed: 'Impossible d’enregistrer les paramètres.',
     autoPasteCodes: 'Coller le code automatiquement',
     autoPasteCodesHint:
@@ -1143,10 +1163,12 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
     hideCodes: 'Codes ausblenden',
     hideCodesHint:
       'Blendet Codes in der Kontoliste aus. Wähle ein Konto aus, um den Code zu kopieren; automatisches Einfügen funktioniert weiterhin.',
-    autoSortCodes: 'Codes automatisch sortieren',
+    autoSortCodes: 'Codes nach Website filtern',
     autoSortCodesHint:
-      'Zeigt, wenn verfügbar, wahrscheinliche Treffer für die aktuelle Website zuerst. Schalte dies aus, um die Codes selbst anzuordnen.',
+      'Zeigt wahrscheinliche Treffer für die aktuelle Website. Du kannst alle Codes durchsuchen oder anzeigen; schalte dies zum Sortieren aus.',
     siteSuggestion: 'Für diese Website vorgeschlagen',
+    showAllCodes: 'Alle Codes anzeigen',
+    showSiteMatches: 'Nur Website-Treffer anzeigen',
     settingsSaveFailed: 'Einstellungen konnten nicht gespeichert werden.',
     autoPasteCodes: 'Code automatisch einfügen',
     autoPasteCodesHint:
@@ -1246,9 +1268,11 @@ const dictionaries: Record<string, Record<MessageKey, string>> = {
     showCountdownSecondsHint: '在圆形倒计时内显示秒数。',
     hideCodes: '隐藏验证码',
     hideCodesHint: '在账户列表中隐藏验证码。选择账户即可复制验证码；自动粘贴仍然有效。',
-    autoSortCodes: '自动排序验证码',
-    autoSortCodesHint: '可用时，优先显示可能与当前网站匹配的验证码。关闭后可手动排列验证码。',
+    autoSortCodes: '按网站筛选验证码',
+    autoSortCodesHint: '显示可能与当前网站匹配的验证码。仍可搜索或显示所有验证码；关闭后可手动排序。',
     siteSuggestion: '为此网站推荐',
+    showAllCodes: '显示所有验证码',
+    showSiteMatches: '仅显示网站匹配项',
     settingsSaveFailed: '无法保存设置。',
     autoPasteCodes: '自动粘贴代码',
     autoPasteCodesHint:

--- a/test/auth/accountRanking.test.ts
+++ b/test/auth/accountRanking.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import {
+  getAccountListView,
   getAccountPageRanking,
   getAccountPageMatchScore,
   rankAccountsForPage
@@ -18,6 +19,53 @@ describe('contextual account ranking', () => {
       'Example'
     ]);
     expect(ranking.suggestedAccountIds).toEqual(new Set([accounts[1].id]));
+  });
+
+  test('shows only site matches until all codes are revealed', () => {
+    const accounts = [account('GitHub'), account('Instagram', 'alice'), account('Instagram', 'bob')];
+    const ranking = getAccountPageRanking(accounts, { hostname: 'instagram.com' });
+
+    const collapsed = getAccountListView(ranking.accounts, ranking.suggestedAccountIds, {
+      query: '',
+      revealAll: false
+    });
+    expect(labels(collapsed.accounts)).toEqual(['Instagram', 'Instagram']);
+    expect(collapsed.contextualAction).toBe('showAll');
+
+    const expanded = getAccountListView(ranking.accounts, ranking.suggestedAccountIds, {
+      query: '',
+      revealAll: true
+    });
+    expect(expanded.accounts).toEqual(ranking.accounts);
+    expect(expanded.contextualAction).toBe('showMatches');
+  });
+
+  test('falls back to all codes when every or no account matches', () => {
+    const accounts = [account('GitHub'), account('Instagram')];
+
+    expect(getAccountListView(accounts, new Set(), { query: '', revealAll: false })).toEqual({
+      accounts,
+      contextualAction: null
+    });
+    expect(
+      getAccountListView(accounts, new Set(accounts.map(({ id }) => id)), {
+        query: '',
+        revealAll: false
+      })
+    ).toEqual({ accounts, contextualAction: null });
+  });
+
+  test('searches every code without offering a redundant reveal action', () => {
+    const instagram = account('Instagram');
+    const github = account('GitHub', 'work account');
+    const accounts = [instagram, github];
+
+    expect(
+      getAccountListView(accounts, new Set([instagram.id]), {
+        query: ' WORK ',
+        revealAll: false
+      })
+    ).toEqual({ accounts: [github], contextualAction: null });
   });
 
   test('matches compact names, punctuation, diacritics, and public suffixes', () => {

--- a/test/auth/accountRanking.test.ts
+++ b/test/auth/accountRanking.test.ts
@@ -21,38 +21,67 @@ describe('contextual account ranking', () => {
     expect(ranking.suggestedAccountIds).toEqual(new Set([accounts[1].id]));
   });
 
-  test('shows only site matches until all codes are revealed', () => {
+  test('keeps site matches and the remaining codes in separate groups', () => {
     const accounts = [account('GitHub'), account('Instagram', 'alice'), account('Instagram', 'bob')];
     const ranking = getAccountPageRanking(accounts, { hostname: 'instagram.com' });
 
     const collapsed = getAccountListView(ranking.accounts, ranking.suggestedAccountIds, {
       query: '',
+      alwaysShowAll: false,
       revealAll: false
     });
     expect(labels(collapsed.accounts)).toEqual(['Instagram', 'Instagram']);
+    expect(collapsed.revealedAccounts).toEqual([]);
+    expect(collapsed.hiddenCount).toBe(1);
     expect(collapsed.contextualAction).toBe('showAll');
 
     const expanded = getAccountListView(ranking.accounts, ranking.suggestedAccountIds, {
       query: '',
+      alwaysShowAll: false,
       revealAll: true
     });
-    expect(expanded.accounts).toEqual(ranking.accounts);
+    expect([...expanded.accounts, ...expanded.revealedAccounts]).toEqual(ranking.accounts);
+    expect(labels(expanded.revealedAccounts)).toEqual(['GitHub']);
+    expect(expanded.hiddenCount).toBe(1);
     expect(expanded.contextualAction).toBe('showMatches');
+  });
+
+  test('drops the grouping entirely when all codes are always shown', () => {
+    const accounts = [account('GitHub'), account('Instagram')];
+    const ranking = getAccountPageRanking(accounts, { hostname: 'instagram.com' });
+
+    expect(
+      getAccountListView(ranking.accounts, ranking.suggestedAccountIds, {
+        query: '',
+        alwaysShowAll: true,
+        revealAll: false
+      })
+    ).toEqual({
+      accounts: ranking.accounts,
+      revealedAccounts: [],
+      hiddenCount: 0,
+      contextualAction: null
+    });
   });
 
   test('falls back to all codes when every or no account matches', () => {
     const accounts = [account('GitHub'), account('Instagram')];
+    const flatView = { accounts, revealedAccounts: [], hiddenCount: 0, contextualAction: null };
 
-    expect(getAccountListView(accounts, new Set(), { query: '', revealAll: false })).toEqual({
-      accounts,
-      contextualAction: null
-    });
+    expect(
+      getAccountListView(accounts, new Set(), {
+        query: '',
+        alwaysShowAll: false,
+        revealAll: false
+      })
+    ).toEqual(flatView);
     expect(
       getAccountListView(accounts, new Set(accounts.map(({ id }) => id)), {
         query: '',
+        alwaysShowAll: false,
         revealAll: false
       })
-    ).toEqual({ accounts, contextualAction: null });
+    ).toEqual(flatView);
   });
 
   test('searches every code without offering a redundant reveal action', () => {
@@ -63,9 +92,15 @@ describe('contextual account ranking', () => {
     expect(
       getAccountListView(accounts, new Set([instagram.id]), {
         query: ' WORK ',
+        alwaysShowAll: false,
         revealAll: false
       })
-    ).toEqual({ accounts: [github], contextualAction: null });
+    ).toEqual({
+      accounts: [github],
+      revealedAccounts: [],
+      hiddenCount: 0,
+      contextualAction: null
+    });
   });
 
   test('matches compact names, punctuation, diacritics, and public suffixes', () => {

--- a/test/auth/backup.test.ts
+++ b/test/auth/backup.test.ts
@@ -12,7 +12,8 @@ const validVaultData: VaultData = {
     showCountdownSeconds: false,
     hideCodes: false,
     autoPasteCodes: false,
-    accountSortMode: 'manual'
+    accountSortMode: 'manual',
+    alwaysShowAllCodes: false
   }
 };
 

--- a/test/auth/vaultRecords.test.ts
+++ b/test/auth/vaultRecords.test.ts
@@ -10,7 +10,8 @@ const vaultData: VaultData = {
     showCountdownSeconds: false,
     hideCodes: false,
     autoPasteCodes: false,
-    accountSortMode: 'manual'
+    accountSortMode: 'manual',
+    alwaysShowAllCodes: false
   }
 };
 

--- a/test/state/authenticator.test.ts
+++ b/test/state/authenticator.test.ts
@@ -197,6 +197,7 @@ describe('AuthenticatorVault persistence and locking', () => {
 
     expect(vault.settings.theme).toBe('system');
     expect(vault.settings.hideCodes).toBe(false);
+    expect(vault.settings.alwaysShowAllCodes).toBe(false);
 
     await vault.updateSettings({
       language: 'fr',
@@ -204,7 +205,8 @@ describe('AuthenticatorVault persistence and locking', () => {
       showCountdownSeconds: true,
       hideCodes: true,
       autoPasteCodes: true,
-      accountSortMode: 'contextual'
+      accountSortMode: 'contextual',
+      alwaysShowAllCodes: true
     });
 
     expect(vault.hasVault).toBe(true);
@@ -220,6 +222,7 @@ describe('AuthenticatorVault persistence and locking', () => {
     expect(reopened.settings.hideCodes).toBe(true);
     expect(reopened.settings.autoPasteCodes).toBe(true);
     expect(reopened.settings.accountSortMode).toBe('contextual');
+    expect(reopened.settings.alwaysShowAllCodes).toBe(true);
   });
 
   test('applies defaults to legacy settings without newer preferences', async () => {
@@ -240,6 +243,7 @@ describe('AuthenticatorVault persistence and locking', () => {
 
     expect(vault.settings.accountSortMode).toBe('contextual');
     expect(vault.settings.hideCodes).toBe(false);
+    expect(vault.settings.alwaysShowAllCodes).toBe(false);
   });
 
   test('merges concurrent settings updates without losing changes', async () => {
@@ -251,7 +255,8 @@ describe('AuthenticatorVault persistence and locking', () => {
       vault.updateSettings({ theme: 'dark' }),
       vault.updateSettings({ showCountdownSeconds: true }),
       vault.updateSettings({ accountSortMode: 'contextual' }),
-      vault.updateSettings({ hideCodes: true })
+      vault.updateSettings({ hideCodes: true }),
+      vault.updateSettings({ alwaysShowAllCodes: true })
     ]);
     await Promise.all([
       vault.updateSettings({ autoPasteCodes: true }),
@@ -264,6 +269,7 @@ describe('AuthenticatorVault persistence and locking', () => {
     expect(vault.settings.hideCodes).toBe(true);
     expect(vault.settings.accountSortMode).toBe('contextual');
     expect(vault.settings.autoPasteCodes).toBe(true);
+    expect(vault.settings.alwaysShowAllCodes).toBe(true);
 
     const reopened = new AuthenticatorVault();
     await reopened.initialize();
@@ -272,6 +278,7 @@ describe('AuthenticatorVault persistence and locking', () => {
     expect(reopened.settings.hideCodes).toBe(true);
     expect(reopened.settings.accountSortMode).toBe('contextual');
     expect(reopened.settings.autoPasteCodes).toBe(true);
+    expect(reopened.settings.alwaysShowAllCodes).toBe(true);
   });
 
   test('finishes a pending settings write before resetting the vault', async () => {
@@ -290,7 +297,8 @@ describe('AuthenticatorVault persistence and locking', () => {
       showCountdownSeconds: false,
       hideCodes: false,
       autoPasteCodes: false,
-      accountSortMode: 'contextual'
+      accountSortMode: 'contextual',
+      alwaysShowAllCodes: false
     });
     expect(await loadStoredVault()).toBeNull();
   });


### PR DESCRIPTION
Hides unmatched codes for sites and adds a show all codes button to keep it focused on auto detected codes.

Closes #15 